### PR TITLE
Withdraw function tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 environments/*/contracts/**
 bin
-
+.vscode/
 # Logs
 logs
 *.log

--- a/test/TESTTokenTest.js
+++ b/test/TESTTokenTest.js
@@ -326,4 +326,15 @@ it("refund: should refund ETH and return their token to pool", async () => {
 
 });
 
+// withdraw
+it("withdraw: should withdraw current avaialbe ETH only for owner", async () => {
+    let withdraw;
+    try {
+        withdraw = await instance.withdraw({from: accounts[4]});
+    } catch(err) {}
+    assert.isUndefined(withdraw);
+
+    withdraw = await instance.withdraw({from: CONTRACT_OWNER_ADDRESS})
+    assert.ok(withdraw)
+});
 });

--- a/test/TESTTokenTest.js
+++ b/test/TESTTokenTest.js
@@ -345,17 +345,17 @@ it("revert: should refund ETH and return allocated token to pool", async () => {
 
 it("withdraw: it should take everything out after Purchase put X ETH in contract", async () => {
     // Create contract, set to Sale, must be whitelisted
-    let instance = await TESTToken.new(NEUREAL_ETH_WALLET, WHITELIST_PROVIDER, {from: CONTRACT_CREATOR_ADDRESS, gas: deployGas, gasPrice: deployGasPrice});
+    let instance = await TESTToken.new(NEUREAL_ETH_WALLET_ADDRESS, WHITELIST_PROVIDER_ADDRESS, {from: CONTRACT_CREATOR_ADDRESS, gas: deployGas, gasPrice: deployGasPrice});
     await instance.transition({from: CONTRACT_CREATOR_ADDRESS});
-    await instance.whitelist(BUYER, {from: WHITELIST_PROVIDER});
+    await instance.whitelist(BUYER_ADDRESS, {from: WHITELIST_PROVIDER_ADDRESS});
 
-    let initBalance = await web3.eth.getBalance(BUYER);
-    let initRefunds = await instance.pendingRefunds_(BUYER);
+    let initBalance = await web3.eth.getBalance(BUYER_ADDRESS);
+    let initRefunds = await instance.pendingRefunds_(BUYER_ADDRESS);
 
     // 1. Purchase tokens on 0.01 ETH
     let value = web3.toWei(0.01, "ether");
-    await instance.sendTransaction({from: BUYER, value: value});
-    let balanceAfter = await web3.eth.getBalance(BUYER);
+    await instance.sendTransaction({from: BUYER_ADDRESS, value: value});
+    let balanceAfter = await web3.eth.getBalance(BUYER_ADDRESS);
     assert.ok(initBalance.greaterThan(balanceAfter), 'Balance withdraw transaction cost');
 
     // 2. Withdraw all contract balance ETH, except MAX_WEI_WITHDRAWAL value
@@ -379,23 +379,23 @@ it("withdraw: it should take everything out after Purchase put X ETH in contract
 
 it("withdraw: it should take only amount in contract, except X from purchase wich is locked in revert pool", async () => {
     // Create contract, set to Sale, must be whitelisted
-    let instance = await TESTToken.new(NEUREAL_ETH_WALLET, WHITELIST_PROVIDER, {from: CONTRACT_CREATOR_ADDRESS, gas: deployGas, gasPrice: deployGasPrice});
+    let instance = await TESTToken.new(NEUREAL_ETH_WALLET_ADDRESS, WHITELIST_PROVIDER_ADDRESS, {from: CONTRACT_CREATOR_ADDRESS, gas: deployGas, gasPrice: deployGasPrice});
     await instance.transition({from: CONTRACT_CREATOR_ADDRESS});
-    await instance.whitelist(BUYER, {from: WHITELIST_PROVIDER});
+    await instance.whitelist(BUYER_ADDRESS, {from: WHITELIST_PROVIDER_ADDRESS});
 
-    let initBalance = await web3.eth.getBalance(BUYER);
-    let initRefunds = await instance.pendingRefunds_(BUYER);
+    let initBalance = await web3.eth.getBalance(BUYER_ADDRESS);
+    let initRefunds = await instance.pendingRefunds_(BUYER_ADDRESS);
 
     // 1. Purchase tokens on 0.01 ETH
     let value = web3.toWei(0.01, "ether");
-    await instance.sendTransaction({from: BUYER, value: value});
-    let balanceAfter = await web3.eth.getBalance(BUYER);
+    await instance.sendTransaction({from: BUYER_ADDRESS, value: value});
+    let balanceAfter = await web3.eth.getBalance(BUYER_ADDRESS);
     assert.ok(initBalance.greaterThan(balanceAfter), 'Balance withdraw transaction cost');
 
     // 2. Refund: Lock ETH to pendingRefund pool
-    await instance.revertPurchase(BUYER, {from: CONTRACT_CREATOR_ADDRESS, value: value});
-    let balanceAfterRevert = await web3.eth.getBalance(BUYER);
-    let pendingRefunds = await instance.pendingRefunds_(BUYER);
+    await instance.revertPurchase(BUYER_ADDRESS, {from: CONTRACT_CREATOR_ADDRESS, value: value});
+    let balanceAfterRevert = await web3.eth.getBalance(BUYER_ADDRESS);
+    let pendingRefunds = await instance.pendingRefunds_(BUYER_ADDRESS);
 
     assert.equal(balanceAfterRevert.toNumber(), balanceAfter.toNumber(), 'ETH should be locked, not sended');
     assert.equal(pendingRefunds, value, 'Refunds should be placed to refund pool')
@@ -425,32 +425,32 @@ it("withdraw: it should take only amount in contract, except X from purchase wic
 
 it("withdraw: It should take everything out but the X from purchase should already be gone (SendRefund sends X ETH back to purchaser)", async () => {
     // Create contract, set to Sale, must be whitelisted
-    let instance = await TESTToken.new(NEUREAL_ETH_WALLET, WHITELIST_PROVIDER, {from: CONTRACT_CREATOR_ADDRESS, gas: deployGas, gasPrice: deployGasPrice});
+    let instance = await TESTToken.new(NEUREAL_ETH_WALLET_ADDRESS, WHITELIST_PROVIDER_ADDRESS, {from: CONTRACT_CREATOR_ADDRESS, gas: deployGas, gasPrice: deployGasPrice});
     await instance.transition({from: CONTRACT_CREATOR_ADDRESS});
-    await instance.whitelist(BUYER, {from: WHITELIST_PROVIDER});
+    await instance.whitelist(BUYER_ADDRESS, {from: WHITELIST_PROVIDER_ADDRESS});
 
-    let initBalance = await web3.eth.getBalance(BUYER);
-    let initRefunds = await instance.pendingRefunds_(BUYER);
+    let initBalance = await web3.eth.getBalance(BUYER_ADDRESS);
+    let initRefunds = await instance.pendingRefunds_(BUYER_ADDRESS);
 
     // 1. Purchase tokens on 0.01 ETH
     let value = web3.toWei(0.01, "ether");
-    await instance.sendTransaction({from: BUYER, value: value});
-    let balanceAfter = await web3.eth.getBalance(BUYER);
+    await instance.sendTransaction({from: BUYER_ADDRESS, value: value});
+    let balanceAfter = await web3.eth.getBalance(BUYER_ADDRESS);
     assert.ok(initBalance.greaterThan(balanceAfter), 'Balance withdraw transaction cost');
 
     // 2. Refund: Lock ETH to pendingRefund pool
-    await instance.revertPurchase(BUYER, {from: CONTRACT_CREATOR_ADDRESS, value: value});
-    let balanceAfterRevert = await web3.eth.getBalance(BUYER);
-    let pendingRefunds = await instance.pendingRefunds_(BUYER);
+    await instance.revertPurchase(BUYER_ADDRESS, {from: CONTRACT_CREATOR_ADDRESS, value: value});
+    let balanceAfterRevert = await web3.eth.getBalance(BUYER_ADDRESS);
+    let pendingRefunds = await instance.pendingRefunds_(BUYER_ADDRESS);
 
     assert.equal(balanceAfterRevert.toNumber(), balanceAfter.toNumber(), 'ETH should be locked, not sended');
     assert.equal(pendingRefunds, value, 'Refunds should be placed to refund pool')
     assert.ok(pendingRefunds.greaterThan(initRefunds), 'Pending refund is greater than initial refund state');
    
     // 3. Send refund to Buyer
-    await instance.sendRefund(BUYER);
-    let balanceAfterRefund = await web3.eth.getBalance(BUYER);
-    let finalRefunds = await instance.pendingRefunds_(BUYER);
+    await instance.sendRefund(BUYER_ADDRESS);
+    let balanceAfterRefund = await web3.eth.getBalance(BUYER_ADDRESS);
+    let finalRefunds = await instance.pendingRefunds_(BUYER_ADDRESS);
 
     assert.ok(balanceAfterRefund.greaterThan(balanceAfterRevert), 'ETH should be sended back to Buyer');
     assert.equal(initRefunds.toNumber(), finalRefunds.toNumber(), 'Refunds pool cleared');
@@ -471,7 +471,7 @@ it("withdraw: It should take everything out but the X from purchase should alrea
     // 6. Withdraw all ETH
     await instance.withdraw({from: CONTRACT_CREATOR_ADDRESS});
     let contractFinalBalance = await web3.eth.getBalance(instance.address);
-    assert.equal(contractFinalBalance.toNumber(), 0,
+    assert.equal(contractFinalBalance, 0,
         'Should withdraw everything including MAX_WEI_WITHDRAWAL, value from purchase already gone'
     )
 

--- a/test/TESTTokenTest.js
+++ b/test/TESTTokenTest.js
@@ -13,28 +13,14 @@ function findEvent(res,evnt) {
 
 contract('TESTToken', async (accounts) => {
 
-const CONTACT_CREATOR = accounts[0];
-const BUYER = accounts[1];
-const NEUREAL_ETH_WALLET = accounts[8];
-const WHITELIST_PROVIDER = accounts[9];
-
-//accounts[0] is owner/contract creator
-console.log('accounts[0] owner: ', accounts[0]);
-//accounts[1-8] is buyer
-console.log('accounts[1] buyer1: ', accounts[1]);
-//accounts[8] is NEUREAL_ETH_WALLET
-console.log('accounts[8] ETH wallet: ', accounts[8]);
-//accounts[9] is WHITELIST_PROVIDER
-console.log('accounts[9] whitelist provider: ', accounts[9]);
-
-// let receipt = await web3.eth.sendTransaction({from: accounts[0], to: accounts[1], value: web3.toWei(1.0, "ether"), gas: 4712388, gasPrice: 100000000000});
-// console.log('receipt: ', receipt);
-
+const CONTRACT_CREATOR_ADDRESS = accounts[0];
+const BUYER_ADDRESS = accounts[1];
+const NEUREAL_ETH_WALLET_ADDRESS = accounts[8];
+const WHITELIST_PROVIDER_ADDRESS = accounts[9];
 
 //CREATION
-
 it("creation: contract should deploy with less than 4.7 mil gas", async () => {
-    let instance = await TESTToken.new(accounts[8], accounts[9], {from: accounts[0], gas: deployGas, gasPrice: deployGasPrice});
+    let instance = await TESTToken.new(NEUREAL_ETH_WALLET_ADDRESS, WHITELIST_PROVIDER_ADDRESS, {from: CONTRACT_CREATOR_ADDRESS, gas: deployGas, gasPrice: deployGasPrice});
 
     let receipt = await web3.eth.getTransactionReceipt(instance.transactionHash);
     console.log('Contract creation (gasUsed): ', receipt.gasUsed);
@@ -43,22 +29,22 @@ it("creation: contract should deploy with less than 4.7 mil gas", async () => {
 
 it("creation: sending ether with contract deployment should revert", async () => {
     try {
-        var result = await TESTToken.new(accounts[8], accounts[9], {from: accounts[0], value: web3.toWei(0.00001, "ether"), gas: deployGas, gasPrice: deployGasPrice});
+        var result = await TESTToken.new(NEUREAL_ETH_WALLET_ADDRESS, WHITELIST_PROVIDER_ADDRESS, {from: CONTRACT_CREATOR_ADDRESS, value: web3.toWei(0.00001, "ether"), gas: deployGas, gasPrice: deployGasPrice});
     } catch(err) { } //console.log(err.message); }
     assert.isUndefined(result);
 });
 
 it("creation: test correct setting of state variables", async() => {
-    let instance = await TESTToken.new(accounts[8], accounts[9], {from: accounts[0], gas: deployGas, gasPrice: deployGasPrice});
+    let instance = await TESTToken.new(NEUREAL_ETH_WALLET_ADDRESS, WHITELIST_PROVIDER_ADDRESS, {from: CONTRACT_CREATOR_ADDRESS, gas: deployGas, gasPrice: deployGasPrice});
 
     let OPENING_RATE = await instance.OPENING_RATE.call();
     assert.equal(OPENING_RATE, 7143);
 
     let NEUREAL_ETH_WALLET = await instance.NEUREAL_ETH_WALLET.call();
-    assert.strictEqual(NEUREAL_ETH_WALLET, accounts[8]);
+    assert.strictEqual(NEUREAL_ETH_WALLET, NEUREAL_ETH_WALLET_ADDRESS);
     
     let WHITELIST_PROVIDER = await instance.WHITELIST_PROVIDER.call();
-    assert.strictEqual(WHITELIST_PROVIDER, accounts[9]);
+    assert.strictEqual(WHITELIST_PROVIDER, WHITELIST_PROVIDER_ADDRESS);
 
     let MAX_SALE = await instance.MAX_SALE.call();
     assert.equal(MAX_SALE, 700 * 10**18);
@@ -78,7 +64,7 @@ it("creation: test correct setting of state variables", async() => {
     assert.isTrue(MAX_WEI_WITHDRAWAL.eq(MAX_WEI_WITHDRAWAL_test.dividedToIntegerBy(OPENING_RATE)));
 
     let owner_ = await instance.owner.call();
-    assert.strictEqual(owner_, accounts[0]);
+    assert.strictEqual(owner_, CONTRACT_CREATOR_ADDRESS);
 
     let totalSale = await instance.totalSale.call();
     assert.equal(totalSale, 0);
@@ -97,7 +83,7 @@ it("creation: test correct setting of state variables", async() => {
 });
 
 it("creation: test correct setting of vanity information", async() => {
-    let instance = await TESTToken.new(accounts[8], accounts[9], {from: accounts[0], gas: deployGas, gasPrice: deployGasPrice});
+    let instance = await TESTToken.new(NEUREAL_ETH_WALLET_ADDRESS, WHITELIST_PROVIDER_ADDRESS, {from: CONTRACT_CREATOR_ADDRESS, gas: deployGas, gasPrice: deployGasPrice});
 
     let name = await instance.name.call();
     assert.strictEqual(name, 'Neureal TGE Test');
@@ -110,12 +96,12 @@ it("creation: test correct setting of vanity information", async() => {
 });
 
 it("creation: should return an initial balance of 0 token for the creator", async () => {
-    let instance = await TESTToken.new(accounts[8], accounts[9], {from: accounts[0], gas: deployGas, gasPrice: deployGasPrice});
+    let instance = await TESTToken.new(NEUREAL_ETH_WALLET_ADDRESS, WHITELIST_PROVIDER_ADDRESS, {from: CONTRACT_CREATOR_ADDRESS, gas: deployGas, gasPrice: deployGasPrice});
 
-    let estimateGas = await instance.balanceOf.estimateGas(accounts[0]);
+    let estimateGas = await instance.balanceOf.estimateGas(CONTRACT_CREATOR_ADDRESS);
     console.log('balanceOf() (estimateGas): ', estimateGas);
 
-    let balanceOf = await instance.balanceOf.call(accounts[0]);
+    let balanceOf = await instance.balanceOf.call(CONTRACT_CREATOR_ADDRESS);
     assert.strictEqual(balanceOf.toNumber(), 0 * 10**18);
 })
 
@@ -124,10 +110,10 @@ it("creation: should return an initial balance of 0 token for the creator", asyn
 //ERC20 Transfers
 
 it("transfers: ERC20 token transfer should be reverted", async () => {
-    let instance = await TESTToken.new(accounts[8], accounts[9], {from: accounts[0], gas: deployGas, gasPrice: deployGasPrice});
+    let instance = await TESTToken.new(NEUREAL_ETH_WALLET_ADDRESS, WHITELIST_PROVIDER_ADDRESS, {from: CONTRACT_CREATOR_ADDRESS, gas: deployGas, gasPrice: deployGasPrice});
 
     try {
-        var result = await instance.transfer(accounts[1], 100, {from: accounts[0]});
+        var result = await instance.transfer(BUYER_ADDRESS, 100, {from: CONTRACT_CREATOR_ADDRESS});
     } catch(err) { } //console.log(err.message); }
     assert.isUndefined(result);
 });
@@ -135,55 +121,55 @@ it("transfers: ERC20 token transfer should be reverted", async () => {
 //Allocate
 
 it("allocate: allocate if not owner should be reverted", async () => {
-    let instance = await TESTToken.new(accounts[8], accounts[9], {from: accounts[0], gas: deployGas, gasPrice: deployGasPrice});
+    let instance = await TESTToken.new(NEUREAL_ETH_WALLET_ADDRESS, WHITELIST_PROVIDER_ADDRESS, {from: CONTRACT_CREATOR_ADDRESS, gas: deployGas, gasPrice: deployGasPrice});
 
     try {
-        var result = await instance.allocate(accounts[2], 100 * 10**18, {from: accounts[1]});
+        var result = await instance.allocate(accounts[2], 100 * 10**18, {from: BUYER_ADDRESS});
     } catch(err) { } //console.log(err.message); }
     assert.isUndefined(result);
 });
 
 it("allocate: allocate to address zero should be reverted", async () => {
-    let instance = await TESTToken.new(accounts[8], accounts[9], {from: accounts[0], gas: deployGas, gasPrice: deployGasPrice});
+    let instance = await TESTToken.new(NEUREAL_ETH_WALLET_ADDRESS, WHITELIST_PROVIDER_ADDRESS, {from: CONTRACT_CREATOR_ADDRESS, gas: deployGas, gasPrice: deployGasPrice});
 
     try {
-        var result = await instance.allocate(0, 100 * 10**18, {from: accounts[0]});
+        var result = await instance.allocate(0, 100 * 10**18, {from: CONTRACT_CREATOR_ADDRESS});
     } catch(err) { } //console.log(err.message); }
     assert.isUndefined(result);
 });
 
 it("allocate: trying to allocate over MAX_ALLOCATION should be reverted", async () => {
-    let instance = await TESTToken.new(accounts[8], accounts[9], {from: accounts[0], gas: deployGas, gasPrice: deployGasPrice});
+    let instance = await TESTToken.new(NEUREAL_ETH_WALLET_ADDRESS, WHITELIST_PROVIDER_ADDRESS, {from: CONTRACT_CREATOR_ADDRESS, gas: deployGas, gasPrice: deployGasPrice});
 
     let MAX_ALLOCATION = await instance.MAX_ALLOCATION.call();
     try {
-        var result = await instance.transfer(accounts[1], MAX_ALLOCATION.add(1), {from: accounts[0]});
+        var result = await instance.transfer(BUYER_ADDRESS, MAX_ALLOCATION.add(1), {from: CONTRACT_CREATOR_ADDRESS});
     } catch(err) { } //console.log(err.message); }
     assert.isUndefined(result);
 });
 
 it("allocate: trying to allocate after state Finalized should be reverted", async () => {
-    let instance = await TESTToken.new(accounts[8], accounts[9], {from: accounts[0], gas: deployGas, gasPrice: deployGasPrice});
+    let instance = await TESTToken.new(NEUREAL_ETH_WALLET_ADDRESS, WHITELIST_PROVIDER_ADDRESS, {from: CONTRACT_CREATOR_ADDRESS, gas: deployGas, gasPrice: deployGasPrice});
 
-    let transition = await instance.transition({from: accounts[0]});
-    transition = await instance.transition({from: accounts[0]});
+    let transition = await instance.transition({from: CONTRACT_CREATOR_ADDRESS});
+    transition = await instance.transition({from: CONTRACT_CREATOR_ADDRESS});
     try {
-        var result = await instance.allocate(accounts[1], 5 * 10**18, {from: accounts[0]});
+        var result = await instance.allocate(BUYER_ADDRESS, 5 * 10**18, {from: CONTRACT_CREATOR_ADDRESS});
     } catch(err) { } //console.log(err.message); }
     assert.isUndefined(result);
 });
 
 it("allocate: should allocate 10 TEST to multiple accounts[i] and emit Transfer events", async () => {
-    let instance = await TESTToken.new(accounts[8], accounts[9], {from: accounts[0], gas: deployGas, gasPrice: deployGasPrice});
+    let instance = await TESTToken.new(NEUREAL_ETH_WALLET_ADDRESS, WHITELIST_PROVIDER_ADDRESS, {from: CONTRACT_CREATOR_ADDRESS, gas: deployGas, gasPrice: deployGasPrice});
 
-    let allocate = await instance.allocate(accounts[1], 10 * 10**18, {from: accounts[0]});
+    let allocate = await instance.allocate(BUYER_ADDRESS, 10 * 10**18, {from: CONTRACT_CREATOR_ADDRESS});
     console.log('allocate (gasUsed): ', allocate.receipt.gasUsed);
     assert.isTrue(findEvent(allocate,"Transfer"));
-    let balanceOf = await instance.balanceOf.call(accounts[1]);
+    let balanceOf = await instance.balanceOf.call(BUYER_ADDRESS);
     assert.strictEqual(balanceOf.toNumber(), 10 * 10**18);
     
     for (let i = 2; i < 6; i++) {
-        let allocate = await instance.allocate(accounts[i], 10 * 10**18, {from: accounts[0]});
+        let allocate = await instance.allocate(accounts[i], 10 * 10**18, {from: CONTRACT_CREATOR_ADDRESS});
         assert.isTrue(findEvent(allocate,"Transfer"));
         let balanceOf = await instance.balanceOf.call(accounts[i]);
         assert.strictEqual(balanceOf.toNumber(), 10 * 10**18);
@@ -196,49 +182,49 @@ it("allocate: should allocate 10 TEST to multiple accounts[i] and emit Transfer 
 //test special functions
 
 it("transition: non-owner trying to call transition function should be reverted", async () => {
-    let instance = await TESTToken.new(accounts[8], accounts[9], {from: accounts[0], gas: deployGas, gasPrice: deployGasPrice});
+    let instance = await TESTToken.new(NEUREAL_ETH_WALLET_ADDRESS, WHITELIST_PROVIDER_ADDRESS, {from: CONTRACT_CREATOR_ADDRESS, gas: deployGas, gasPrice: deployGasPrice});
 
     try {
-        var result = await instance.transition({from: accounts[1]});
+        var result = await instance.transition({from: BUYER_ADDRESS});
     } catch(err) { } //console.log(err.message); }
     assert.isUndefined(result);
 });
 
 it("transition: should cycle state from BeforeSale to Sale to Finalized using transition function, then revert on 3rd time", async () => {
-    let instance = await TESTToken.new(accounts[8], accounts[9], {from: accounts[0], gas: deployGas, gasPrice: deployGasPrice});
+    let instance = await TESTToken.new(NEUREAL_ETH_WALLET_ADDRESS, WHITELIST_PROVIDER_ADDRESS, {from: CONTRACT_CREATOR_ADDRESS, gas: deployGas, gasPrice: deployGasPrice});
 
     let phase = await instance.phase.call();
     assert.strictEqual(phase.toString(10), '0');
 
-    let transition = await instance.transition({from: accounts[0]});
+    let transition = await instance.transition({from: CONTRACT_CREATOR_ADDRESS});
     phase = await instance.phase.call();
     assert.strictEqual(phase.toString(10), '1');
 
-    transition = await instance.transition({from: accounts[0]});
+    transition = await instance.transition({from: CONTRACT_CREATOR_ADDRESS});
     phase = await instance.phase.call();
     assert.strictEqual(phase.toString(10), '2');
 
     try {
-        var result = await instance.transition({from: accounts[0]});
+        var result = await instance.transition({from: CONTRACT_CREATOR_ADDRESS});
     } catch(err) { } //console.log(err.message); }
     assert.isUndefined(result);
 
 });
 
 it("whitelist: non WHITELIST_PROVIDER trying to call whitelist function should be reverted", async () => {
-    let instance = await TESTToken.new(accounts[8], accounts[9], {from: accounts[0], gas: deployGas, gasPrice: deployGasPrice});
+    let instance = await TESTToken.new(NEUREAL_ETH_WALLET_ADDRESS, WHITELIST_PROVIDER_ADDRESS, {from: CONTRACT_CREATOR_ADDRESS, gas: deployGas, gasPrice: deployGasPrice});
 
     try {
-        var result = await instance.whitelist(accounts[1], {from: accounts[0]});
+        var result = await instance.whitelist(BUYER_ADDRESS, {from: CONTRACT_CREATOR_ADDRESS});
     } catch(err) { } //console.log(err.message); }
     assert.isUndefined(result);
 });
 
 it("whitelist: should add address to whitelist", async () => {
-    let instance = await TESTToken.new(accounts[8], accounts[9], {from: accounts[0], gas: deployGas, gasPrice: deployGasPrice});
+    let instance = await TESTToken.new(NEUREAL_ETH_WALLET_ADDRESS, WHITELIST_PROVIDER_ADDRESS, {from: CONTRACT_CREATOR_ADDRESS, gas: deployGas, gasPrice: deployGasPrice});
 
-    let whitelist = await instance.whitelist(accounts[1], {from: accounts[9]});
-    let result = await instance.whitelisted(accounts[1]);
+    let whitelist = await instance.whitelist(BUYER_ADDRESS, {from: WHITELIST_PROVIDER_ADDRESS});
+    let result = await instance.whitelisted(BUYER_ADDRESS);
     assert.isTrue(result);
 });
 
@@ -246,52 +232,52 @@ it("whitelist: should add address to whitelist", async () => {
 //Purchase
 
 it("purchase: trying to purchase over MAX_SALE should be reverted", async () => {
-    let instance = await TESTToken.new(accounts[8], accounts[9], {from: accounts[0], gas: deployGas, gasPrice: deployGasPrice});
+    let instance = await TESTToken.new(NEUREAL_ETH_WALLET_ADDRESS, WHITELIST_PROVIDER_ADDRESS, {from: CONTRACT_CREATOR_ADDRESS, gas: deployGas, gasPrice: deployGasPrice});
 
-    let transition = await instance.transition({from: accounts[0]}); //set to Sale
-    let whitelist = await instance.whitelist(accounts[1], {from: accounts[9]}); //must be whitelisted
+    let transition = await instance.transition({from: CONTRACT_CREATOR_ADDRESS}); //set to Sale
+    let whitelist = await instance.whitelist(BUYER_ADDRESS, {from: WHITELIST_PROVIDER_ADDRESS}); //must be whitelisted
 
     let MAX_SALE = await instance.MAX_SALE.call();
     let OPENING_RATE = await instance.OPENING_RATE.call();
     let value = MAX_SALE.dividedToIntegerBy(OPENING_RATE).add(1) ; //Amount to purchase with
     try {
-        var result = await instance.sendTransaction({from: accounts[1], value: value, gas: 4712388, gasPrice: 100000000000});
+        var result = await instance.sendTransaction({from: BUYER_ADDRESS, value: value, gas: 4712388, gasPrice: 100000000000});
     } catch(err) { } //console.log(err.message); }
     assert.isUndefined(result);
 });
 
 it("purchase: should purchase token by sending ether to contract fallback function", async () => {
-    let instance = await TESTToken.new(accounts[8], accounts[9], {from: accounts[0], gas: deployGas, gasPrice: deployGasPrice});
+    let instance = await TESTToken.new(NEUREAL_ETH_WALLET_ADDRESS, WHITELIST_PROVIDER_ADDRESS, {from: CONTRACT_CREATOR_ADDRESS, gas: deployGas, gasPrice: deployGasPrice});
 
-    let transition = await instance.transition({from: accounts[0]}); //set to Sale
-    let whitelist = await instance.whitelist(accounts[1], {from: accounts[9]}); //must be whitelisted
+    let transition = await instance.transition({from: CONTRACT_CREATOR_ADDRESS}); //set to Sale
+    let whitelist = await instance.whitelist(BUYER_ADDRESS, {from: WHITELIST_PROVIDER_ADDRESS}); //must be whitelisted
     
     let value = web3.toWei(0.01, "ether"); //Amount to purchase with
-    var purchase = await instance.sendTransaction({from: accounts[1], value: value, gas: 4712388, gasPrice: 100000000000});
+    var purchase = await instance.sendTransaction({from: BUYER_ADDRESS, value: value, gas: 4712388, gasPrice: 100000000000});
     console.log('purchase (gasUsed): ', purchase.receipt.gasUsed);
     assert.isTrue(findEvent(purchase,"Transfer"));
     assert.isTrue(findEvent(purchase,"TokenPurchase"));
     
     let OPENING_RATE = await instance.OPENING_RATE.call();
-    let balanceOf = await instance.balanceOf.call(accounts[1]);
+    let balanceOf = await instance.balanceOf.call(BUYER_ADDRESS);
     // console.log('balanceOf: ', balanceOf.toString(10));
     // console.log('buy: ', OPENING_RATE.times(value).toString(10));
     assert.isTrue(balanceOf.eq(OPENING_RATE.times(value)));
 });
 
 it("withdrawl: should withdrawl all ether in the contract up to MAX_WEI_WITHDRAWAL", async () => {
-    let instance = await TESTToken.new(accounts[8], accounts[9], {from: accounts[0], gas: deployGas, gasPrice: deployGasPrice});
+    let instance = await TESTToken.new(NEUREAL_ETH_WALLET_ADDRESS, WHITELIST_PROVIDER_ADDRESS, {from: CONTRACT_CREATOR_ADDRESS, gas: deployGas, gasPrice: deployGasPrice});
 
-    let transition = await instance.transition({from: accounts[0]}); //set to Sale
-    let whitelist = await instance.whitelist(accounts[1], {from: accounts[9]}); //must be whitelisted
+    let transition = await instance.transition({from: CONTRACT_CREATOR_ADDRESS}); //set to Sale
+    let whitelist = await instance.whitelist(BUYER_ADDRESS, {from: WHITELIST_PROVIDER_ADDRESS}); //must be whitelisted
     
     let value = web3.toWei(0.01, "ether"); //Amount to purchase with
-    var purchase = await instance.sendTransaction({from: accounts[1], value: value, gas: 4712388, gasPrice: 100000000000});
+    var purchase = await instance.sendTransaction({from: BUYER_ADDRESS, value: value, gas: 4712388, gasPrice: 100000000000});
     
     let balance_before = await web3.eth.getBalance(instance.address);
     console.log('before withdraw: balance[%s]', balance_before.toString(10));
 
-    let withdraw = await instance.withdraw({from: accounts[0]});
+    let withdraw = await instance.withdraw({from: CONTRACT_CREATOR_ADDRESS});
 
     let balance_after = await web3.eth.getBalance(instance.address);
     console.log('after withdraw: balance[%s]', balance_after.toString(10));
@@ -303,16 +289,16 @@ it("withdrawl: should withdrawl all ether in the contract up to MAX_WEI_WITHDRAW
 //Revert
 
 it("revert: should refund ETH and return allocated token to pool", async () => {
-    let instance = await TESTToken.new(accounts[8], accounts[9], {from: accounts[0], gas: deployGas, gasPrice: deployGasPrice});
+    let instance = await TESTToken.new(NEUREAL_ETH_WALLET_ADDRESS, WHITELIST_PROVIDER_ADDRESS, {from: CONTRACT_CREATOR_ADDRESS, gas: deployGas, gasPrice: deployGasPrice});
     
     let OPENING_RATE = await instance.OPENING_RATE.call();
 
-    let transition = await instance.transition({from: accounts[0]}); //set to Sale
-    let whitelist = await instance.whitelist(accounts[1], {from: accounts[9]}); //must be whitelisted
+    let transition = await instance.transition({from: CONTRACT_CREATOR_ADDRESS}); //set to Sale
+    let whitelist = await instance.whitelist(BUYER_ADDRESS, {from: WHITELIST_PROVIDER_ADDRESS}); //must be whitelisted
     
     let totalSupply = await instance.totalSupply.call();
     let totalSale = await instance.totalSale.call();
-    let balanceOf = await instance.balanceOf.call(accounts[1]);
+    let balanceOf = await instance.balanceOf.call(BUYER_ADDRESS);
     let totalWei = await instance.totalWei.call();
     let balance = await web3.eth.getBalance(instance.address);
     let totalRefunds_ = await instance.totalRefunds_.call();
@@ -322,13 +308,13 @@ it("revert: should refund ETH and return allocated token to pool", async () => {
 
     // purchase
     let value = web3.toWei(0.01, "ether"); //Amount to purchase with
-    var purchase = await instance.sendTransaction({from: accounts[1], value: value, gas: 4712388, gasPrice: 100000000000});
+    var purchase = await instance.sendTransaction({from: BUYER_ADDRESS, value: value, gas: 4712388, gasPrice: 100000000000});
     assert.isTrue(findEvent(purchase,"Transfer"));
     assert.isTrue(findEvent(purchase,"TokenPurchase"));
 
     totalSupply = await instance.totalSupply.call();
     totalSale = await instance.totalSale.call();
-    balanceOf = await instance.balanceOf.call(accounts[1]);
+    balanceOf = await instance.balanceOf.call(BUYER_ADDRESS);
     totalWei = await instance.totalWei.call();
     balance = await web3.eth.getBalance(instance.address);
     totalRefunds_ = await instance.totalRefunds_.call();
@@ -340,13 +326,13 @@ it("revert: should refund ETH and return allocated token to pool", async () => {
 
 
     // revert
-    let revert = await instance.revertPurchase(accounts[1], {from: accounts[0], value: value, gas: 4712388, gasPrice: 100000000000}); //execute revert
+    let revert = await instance.revertPurchase(BUYER_ADDRESS, {from: CONTRACT_CREATOR_ADDRESS, value: value, gas: 4712388, gasPrice: 100000000000}); //execute revert
     console.log('revertPurchase (gasUsed): ', revert.receipt.gasUsed);
     assert.isTrue(findEvent(revert,"Transfer"));
 
     totalSupply = await instance.totalSupply.call();
     totalSale = await instance.totalSale.call();
-    balanceOf = await instance.balanceOf.call(accounts[1]);
+    balanceOf = await instance.balanceOf.call(BUYER_ADDRESS);
     totalWei = await instance.totalWei.call();
     balance = await web3.eth.getBalance(instance.address);
     totalRefunds_ = await instance.totalRefunds_.call();
@@ -359,8 +345,8 @@ it("revert: should refund ETH and return allocated token to pool", async () => {
 
 it("withdraw: it should take everything out after Purchase put X ETH in contract", async () => {
     // Create contract, set to Sale, must be whitelisted
-    let instance = await TESTToken.new(NEUREAL_ETH_WALLET, WHITELIST_PROVIDER, {from: CONTACT_CREATOR, gas: deployGas, gasPrice: deployGasPrice});
-    await instance.transition({from: CONTACT_CREATOR});
+    let instance = await TESTToken.new(NEUREAL_ETH_WALLET, WHITELIST_PROVIDER, {from: CONTRACT_CREATOR_ADDRESS, gas: deployGas, gasPrice: deployGasPrice});
+    await instance.transition({from: CONTRACT_CREATOR_ADDRESS});
     await instance.whitelist(BUYER, {from: WHITELIST_PROVIDER});
 
     let initBalance = await web3.eth.getBalance(BUYER);
@@ -373,7 +359,7 @@ it("withdraw: it should take everything out after Purchase put X ETH in contract
     assert.ok(initBalance.greaterThan(balanceAfter), 'Balance withdraw transaction cost');
 
     // 2. Withdraw all contract balance ETH, except MAX_WEI_WITHDRAWAL value
-    await instance.withdraw({from: CONTACT_CREATOR});
+    await instance.withdraw({from: CONTRACT_CREATOR_ADDRESS});
     let contractAfterBalance = await web3.eth.getBalance(instance.address);
     let MAX_WEI_WITHDRAWAL = await instance.MAX_WEI_WITHDRAWAL.call();
     let valueBigNumber = new web3.BigNumber(value);
@@ -382,10 +368,10 @@ it("withdraw: it should take everything out after Purchase put X ETH in contract
     assert.equal(contractAfterBalance.toNumber(), contractEthLeft.toNumber(), 'Withdraw everything, but MAX_WEI_WITHDRAWAL should left')
 
     // 3. Set Finalized phase for withdraw everything:
-    await instance.transition({from: CONTACT_CREATOR});
+    await instance.transition({from: CONTRACT_CREATOR_ADDRESS});
     
     // 4. Withdraw all ETH
-    await instance.withdraw({from: CONTACT_CREATOR});
+    await instance.withdraw({from: CONTRACT_CREATOR_ADDRESS});
     let contractFinalBalance = await web3.eth.getBalance(instance.address);
     assert.equal(contractFinalBalance.toNumber(), 0, 'Should withdraw everything after sale ends')
 
@@ -393,8 +379,8 @@ it("withdraw: it should take everything out after Purchase put X ETH in contract
 
 it("withdraw: it should take only amount in contract, except X from purchase wich is locked in revert pool", async () => {
     // Create contract, set to Sale, must be whitelisted
-    let instance = await TESTToken.new(NEUREAL_ETH_WALLET, WHITELIST_PROVIDER, {from: CONTACT_CREATOR, gas: deployGas, gasPrice: deployGasPrice});
-    await instance.transition({from: CONTACT_CREATOR});
+    let instance = await TESTToken.new(NEUREAL_ETH_WALLET, WHITELIST_PROVIDER, {from: CONTRACT_CREATOR_ADDRESS, gas: deployGas, gasPrice: deployGasPrice});
+    await instance.transition({from: CONTRACT_CREATOR_ADDRESS});
     await instance.whitelist(BUYER, {from: WHITELIST_PROVIDER});
 
     let initBalance = await web3.eth.getBalance(BUYER);
@@ -407,7 +393,7 @@ it("withdraw: it should take only amount in contract, except X from purchase wic
     assert.ok(initBalance.greaterThan(balanceAfter), 'Balance withdraw transaction cost');
 
     // 2. Refund: Lock ETH to pendingRefund pool
-    await instance.revertPurchase(BUYER, {from: CONTACT_CREATOR, value: value});
+    await instance.revertPurchase(BUYER, {from: CONTRACT_CREATOR_ADDRESS, value: value});
     let balanceAfterRevert = await web3.eth.getBalance(BUYER);
     let pendingRefunds = await instance.pendingRefunds_(BUYER);
 
@@ -416,7 +402,7 @@ it("withdraw: it should take only amount in contract, except X from purchase wic
     assert.ok(pendingRefunds.greaterThan(initRefunds), 'Pending refund is greater than initial refund state');
 
     // 3. Withdraw all contract balance ETH, except MAX_WEI_WITHDRAWAL value
-    await instance.withdraw({from: CONTACT_CREATOR});
+    await instance.withdraw({from: CONTRACT_CREATOR_ADDRESS});
     let contractAfterBalance = await web3.eth.getBalance(instance.address);
     let MAX_WEI_WITHDRAWAL = await instance.MAX_WEI_WITHDRAWAL.call();
     let valueBigNumber = new web3.BigNumber(value);
@@ -426,10 +412,10 @@ it("withdraw: it should take only amount in contract, except X from purchase wic
     );
 
     // 4. Set Finalized phase for withdraw everything:
-    await instance.transition({from: CONTACT_CREATOR});
+    await instance.transition({from: CONTRACT_CREATOR_ADDRESS});
     
     // 5. Withdraw all ETH
-    await instance.withdraw({from: CONTACT_CREATOR});
+    await instance.withdraw({from: CONTRACT_CREATOR_ADDRESS});
     let contractFinalBalance = await web3.eth.getBalance(instance.address);
     assert.equal(contractFinalBalance.toNumber(), valueBigNumber.toNumber(10),
         'Should withdraw everything including MAX_WEI_WITHDRAWAL, but refund pending pool should left'
@@ -439,8 +425,8 @@ it("withdraw: it should take only amount in contract, except X from purchase wic
 
 it("withdraw: It should take everything out but the X from purchase should already be gone (SendRefund sends X ETH back to purchaser)", async () => {
     // Create contract, set to Sale, must be whitelisted
-    let instance = await TESTToken.new(NEUREAL_ETH_WALLET, WHITELIST_PROVIDER, {from: CONTACT_CREATOR, gas: deployGas, gasPrice: deployGasPrice});
-    await instance.transition({from: CONTACT_CREATOR});
+    let instance = await TESTToken.new(NEUREAL_ETH_WALLET, WHITELIST_PROVIDER, {from: CONTRACT_CREATOR_ADDRESS, gas: deployGas, gasPrice: deployGasPrice});
+    await instance.transition({from: CONTRACT_CREATOR_ADDRESS});
     await instance.whitelist(BUYER, {from: WHITELIST_PROVIDER});
 
     let initBalance = await web3.eth.getBalance(BUYER);
@@ -453,7 +439,7 @@ it("withdraw: It should take everything out but the X from purchase should alrea
     assert.ok(initBalance.greaterThan(balanceAfter), 'Balance withdraw transaction cost');
 
     // 2. Refund: Lock ETH to pendingRefund pool
-    await instance.revertPurchase(BUYER, {from: CONTACT_CREATOR, value: value});
+    await instance.revertPurchase(BUYER, {from: CONTRACT_CREATOR_ADDRESS, value: value});
     let balanceAfterRevert = await web3.eth.getBalance(BUYER);
     let pendingRefunds = await instance.pendingRefunds_(BUYER);
 
@@ -470,7 +456,7 @@ it("withdraw: It should take everything out but the X from purchase should alrea
     assert.equal(initRefunds.toNumber(), finalRefunds.toNumber(), 'Refunds pool cleared');
 
     // 4. Withdraw all contract balance ETH, except MAX_WEI_WITHDRAWAL value
-    await instance.withdraw({from: CONTACT_CREATOR});
+    await instance.withdraw({from: CONTRACT_CREATOR_ADDRESS});
     let contractAfterBalance = await web3.eth.getBalance(instance.address);
     let MAX_WEI_WITHDRAWAL = await instance.MAX_WEI_WITHDRAWAL.call();
     let valueBigNumber = new web3.BigNumber(value);
@@ -479,11 +465,11 @@ it("withdraw: It should take everything out but the X from purchase should alrea
         'Should withdraw everything, except value from revert pending pool + MAX_WEI_WITHDRAWAL'
     );
 
-    // 4. Set Finalized phase for withdraw everything:
-    await instance.transition({from: CONTACT_CREATOR});
+    // 5. Set Finalized phase for withdraw everything:
+    await instance.transition({from: CONTRACT_CREATOR_ADDRESS});
     
-    // 5. Withdraw all ETH
-    await instance.withdraw({from: CONTACT_CREATOR});
+    // 6. Withdraw all ETH
+    await instance.withdraw({from: CONTRACT_CREATOR_ADDRESS});
     let contractFinalBalance = await web3.eth.getBalance(instance.address);
     assert.equal(contractFinalBalance.toNumber(), 0,
         'Should withdraw everything including MAX_WEI_WITHDRAWAL, value from purchase already gone'

--- a/test/TESTTokenTest.js
+++ b/test/TESTTokenTest.js
@@ -24,13 +24,17 @@ console.log('accounts[9] whitelist provider: ', accounts[9]);
 
 // let receipt = await web3.eth.sendTransaction({from: accounts[0], to: accounts[1], value: web3.toWei(1.0, "ether"), gas: 4712388, gasPrice: 100000000000});
 // console.log('receipt: ', receipt);
+let instance;
 
+beforeEach('some description', async () => {
+    // beforeEach:some description
+    instance = await TESTToken.new(accounts[8], accounts[9], {from: accounts[0], gas: deployGas, gasPrice: deployGasPrice});
+
+});
 
 //CREATION
 
 it("creation: contract should deploy with less than 4.7 mil gas", async () => {
-    let instance = await TESTToken.new(accounts[8], accounts[9], {from: accounts[0], gas: deployGas, gasPrice: deployGasPrice});
-
     let receipt = await web3.eth.getTransactionReceipt(instance.transactionHash);
     console.log('Contract creation (gasUsed): ', receipt.gasUsed);
     assert.isBelow(receipt.gasUsed, 4700000);
@@ -44,7 +48,6 @@ it("creation: sending ether with contract deployment should revert", async () =>
 });
 
 it("creation: test correct setting of state variables", async() => {
-    let instance = await TESTToken.new(accounts[8], accounts[9], {from: accounts[0], gas: deployGas, gasPrice: deployGasPrice});
 
     let OPENING_RATE = await instance.OPENING_RATE.call();
     assert.equal(OPENING_RATE, 7143);
@@ -92,8 +95,6 @@ it("creation: test correct setting of state variables", async() => {
 });
 
 it("creation: test correct setting of vanity information", async() => {
-    let instance = await TESTToken.new(accounts[8], accounts[9], {from: accounts[0], gas: deployGas, gasPrice: deployGasPrice});
-
     let name = await instance.name.call();
     assert.strictEqual(name, 'Neureal TGE Test');
 
@@ -105,8 +106,6 @@ it("creation: test correct setting of vanity information", async() => {
 });
 
 it("creation: should return an initial balance of 0 token for the creator", async () => {
-    let instance = await TESTToken.new(accounts[8], accounts[9], {from: accounts[0], gas: deployGas, gasPrice: deployGasPrice});
-
     let estimateGas = await instance.balanceOf.estimateGas(accounts[0]);
     console.log('balanceOf() (estimateGas): ', estimateGas);
 
@@ -119,8 +118,6 @@ it("creation: should return an initial balance of 0 token for the creator", asyn
 //ERC20 Transfers
 
 it("transfers: ERC20 token transfer should be reverted", async () => {
-    let instance = await TESTToken.new(accounts[8], accounts[9], {from: accounts[0], gas: deployGas, gasPrice: deployGasPrice});
-
     try {
         var result = await instance.transfer(accounts[1], 100, {from: accounts[0]});
     } catch(err) { } //console.log(err.message); }
@@ -130,8 +127,6 @@ it("transfers: ERC20 token transfer should be reverted", async () => {
 //Allocate
 
 it("allocate: allocate if not owner should be reverted", async () => {
-    let instance = await TESTToken.new(accounts[8], accounts[9], {from: accounts[0], gas: deployGas, gasPrice: deployGasPrice});
-
     try {
         var result = await instance.allocate(accounts[2], 100 * 10**18, {from: accounts[1]});
     } catch(err) { } //console.log(err.message); }
@@ -139,8 +134,6 @@ it("allocate: allocate if not owner should be reverted", async () => {
 });
 
 it("allocate: allocate to address zero should be reverted", async () => {
-    let instance = await TESTToken.new(accounts[8], accounts[9], {from: accounts[0], gas: deployGas, gasPrice: deployGasPrice});
-
     try {
         var result = await instance.allocate(0, 100 * 10**18, {from: accounts[0]});
     } catch(err) { } //console.log(err.message); }
@@ -148,8 +141,6 @@ it("allocate: allocate to address zero should be reverted", async () => {
 });
 
 it("allocate: trying to allocate over MAX_ALLOCATION should be reverted", async () => {
-    let instance = await TESTToken.new(accounts[8], accounts[9], {from: accounts[0], gas: deployGas, gasPrice: deployGasPrice});
-
     let MAX_ALLOCATION = await instance.MAX_ALLOCATION.call();
     try {
         var result = await instance.transfer(accounts[1], MAX_ALLOCATION.add(1), {from: accounts[0]});
@@ -158,8 +149,6 @@ it("allocate: trying to allocate over MAX_ALLOCATION should be reverted", async 
 });
 
 it("allocate: trying to allocate after state Finalized should be reverted", async () => {
-    let instance = await TESTToken.new(accounts[8], accounts[9], {from: accounts[0], gas: deployGas, gasPrice: deployGasPrice});
-
     let transition = await instance.transition({from: accounts[0]});
     transition = await instance.transition({from: accounts[0]});
     try {
@@ -169,8 +158,6 @@ it("allocate: trying to allocate after state Finalized should be reverted", asyn
 });
 
 it("allocate: should allocate 10 TEST to multiple accounts[i] and emit Transfer events", async () => {
-    let instance = await TESTToken.new(accounts[8], accounts[9], {from: accounts[0], gas: deployGas, gasPrice: deployGasPrice});
-
     let allocate = await instance.allocate(accounts[1], 10 * 10**18, {from: accounts[0]});
     console.log('allocate (gasUsed): ', allocate.receipt.gasUsed);
     assert.isTrue(findEvent(allocate,"Transfer"));
@@ -191,8 +178,6 @@ it("allocate: should allocate 10 TEST to multiple accounts[i] and emit Transfer 
 //test special functions
 
 it("transition: non-owner trying to call transition function should be reverted", async () => {
-    let instance = await TESTToken.new(accounts[8], accounts[9], {from: accounts[0], gas: deployGas, gasPrice: deployGasPrice});
-
     try {
         var result = await instance.transition({from: accounts[1]});
     } catch(err) { } //console.log(err.message); }
@@ -200,8 +185,6 @@ it("transition: non-owner trying to call transition function should be reverted"
 });
 
 it("transition: should cycle state from BeforeSale to Sale to Finalized using transition function, then revert on 3rd time", async () => {
-    let instance = await TESTToken.new(accounts[8], accounts[9], {from: accounts[0], gas: deployGas, gasPrice: deployGasPrice});
-
     let phase_ = await instance.phase_.call();
     assert.strictEqual(phase_.toString(10), '0');
 
@@ -221,8 +204,6 @@ it("transition: should cycle state from BeforeSale to Sale to Finalized using tr
 });
 
 it("whitelist: non WHITELIST_PROVIDER trying to call whitelist function should be reverted", async () => {
-    let instance = await TESTToken.new(accounts[8], accounts[9], {from: accounts[0], gas: deployGas, gasPrice: deployGasPrice});
-
     try {
         var result = await instance.whitelist(accounts[1], {from: accounts[0]});
     } catch(err) { } //console.log(err.message); }
@@ -230,8 +211,6 @@ it("whitelist: non WHITELIST_PROVIDER trying to call whitelist function should b
 });
 
 it("whitelist: should add address to whitelist", async () => {
-    let instance = await TESTToken.new(accounts[8], accounts[9], {from: accounts[0], gas: deployGas, gasPrice: deployGasPrice});
-
     let whitelist = await instance.whitelist(accounts[1], {from: accounts[9]});
     let result = await instance.whitelist_(accounts[1]);
     assert.isTrue(result);
@@ -241,8 +220,6 @@ it("whitelist: should add address to whitelist", async () => {
 //Purchase
 
 it("purchase: trying to purchase over MAX_SALE should be reverted", async () => {
-    let instance = await TESTToken.new(accounts[8], accounts[9], {from: accounts[0], gas: deployGas, gasPrice: deployGasPrice});
-
     let transition = await instance.transition({from: accounts[0]}); //set to Sale
     let whitelist = await instance.whitelist(accounts[1], {from: accounts[9]}); //must be whitelisted
 
@@ -256,8 +233,6 @@ it("purchase: trying to purchase over MAX_SALE should be reverted", async () => 
 });
 
 it("purchase: should purchase token by sending ether to contract fallback function", async () => {
-    let instance = await TESTToken.new(accounts[8], accounts[9], {from: accounts[0], gas: deployGas, gasPrice: deployGasPrice});
-
     let transition = await instance.transition({from: accounts[0]}); //set to Sale
     let whitelist = await instance.whitelist(accounts[1], {from: accounts[9]}); //must be whitelisted
     
@@ -275,8 +250,6 @@ it("purchase: should purchase token by sending ether to contract fallback functi
 });
 
 it("withdrawl: should withdrawl all ether in the contract up to MAX_WEI_WITHDRAWAL", async () => {
-    let instance = await TESTToken.new(accounts[8], accounts[9], {from: accounts[0], gas: deployGas, gasPrice: deployGasPrice});
-
     let transition = await instance.transition({from: accounts[0]}); //set to Sale
     let whitelist = await instance.whitelist(accounts[1], {from: accounts[9]}); //must be whitelisted
     
@@ -298,8 +271,6 @@ it("withdrawl: should withdrawl all ether in the contract up to MAX_WEI_WITHDRAW
 //Refund
 
 it("refund: should refund ETH and return their token to pool", async () => {
-    let instance = await TESTToken.new(accounts[8], accounts[9], {from: accounts[0], gas: deployGas, gasPrice: deployGasPrice});
-    
     let OPENING_RATE = await instance.OPENING_RATE.call();
 
     let transition = await instance.transition({from: accounts[0]}); //set to Sale

--- a/test/TESTTokenTest.js
+++ b/test/TESTTokenTest.js
@@ -343,14 +343,21 @@ it("revert: should refund ETH and return allocated token to pool", async () => {
 
 });
 
-it("withdraw: it should take everything out after Purchase put X ETH in contract", async () => {
+it("transaction: should check buyer balance before/after transaction", async () => {
+
+});
+
+it("transcation: should check contract balance before/after transaction", async () => {
+    
+});
+
+it("withdraw: should take everything out after Purchase put X ETH in contract", async () => {
     // Create contract, set to Sale, must be whitelisted
     let instance = await TESTToken.new(NEUREAL_ETH_WALLET_ADDRESS, WHITELIST_PROVIDER_ADDRESS, {from: CONTRACT_CREATOR_ADDRESS, gas: deployGas, gasPrice: deployGasPrice});
     let MAX_WEI_WITHDRAWAL = await instance.MAX_WEI_WITHDRAWAL.call();
     await instance.transition({from: CONTRACT_CREATOR_ADDRESS});
     await instance.whitelist(BUYER_ADDRESS, {from: WHITELIST_PROVIDER_ADDRESS});
 
-    let initBalance = await web3.eth.getBalance(BUYER_ADDRESS);
     let value = web3.toWei(0.01, "ether");
 
     // 1. Purchase tokens on 0.01 ETH
@@ -362,7 +369,7 @@ it("withdraw: it should take everything out after Purchase put X ETH in contract
 
     let contractAfterBalance = await web3.eth.getBalance(instance.address);
     const contractEthLeft = contractBalanceBeforeWithdraw.sub(MAX_WEI_WITHDRAWAL);
-    assert.isTrue(contractAfterBalance.eq(contractEthLeft), 'Withdraw everything, but MAX_WEI_WITHDRAWAL should left')
+    assert.isTrue(contractAfterBalance.eq(contractEthLeft), 'Withdraw MAX_WEI_WITHDRAWAL')
 
     // 3. Set Finalized phase for withdraw everything:
     await instance.transition({from: CONTRACT_CREATOR_ADDRESS});
@@ -375,101 +382,79 @@ it("withdraw: it should take everything out after Purchase put X ETH in contract
 
 });
 
-it("withdraw: it should take only amount in contract, except X from purchase wich is locked in revert pool", async () => {
+it("withdraw: it should take only amount in contract, except X from purchase which is locked in revert pool", async () => {
     // Create contract, set to Sale, must be whitelisted
     let instance = await TESTToken.new(NEUREAL_ETH_WALLET_ADDRESS, WHITELIST_PROVIDER_ADDRESS, {from: CONTRACT_CREATOR_ADDRESS, gas: deployGas, gasPrice: deployGasPrice});
     await instance.transition({from: CONTRACT_CREATOR_ADDRESS});
     await instance.whitelist(BUYER_ADDRESS, {from: WHITELIST_PROVIDER_ADDRESS});
-
-    let initContractBalance = await web3.eth.getBalance(instance.address);
-    let initBalance = await web3.eth.getBalance(BUYER_ADDRESS);
-    let initRefunds = await instance.pendingRefunds_(BUYER_ADDRESS);
+    let value = web3.toWei(0.01, "ether");
+    let MAX_WEI_WITHDRAWAL = await instance.MAX_WEI_WITHDRAWAL.call();
 
     // 1. Purchase tokens on 0.01 ETH
-    let value = web3.toWei(0.01, "ether");
-    let transaction = await instance.sendTransaction({from: BUYER_ADDRESS, value: value});
-    const tx = await web3.eth.getTransaction(transaction.tx);
-
+    const transaction = await instance.sendTransaction({from: BUYER_ADDRESS, value: value});
     let balanceAfter = await web3.eth.getBalance(BUYER_ADDRESS);
-    let contractBalanceAfter = await web3.eth.getBalance(instance.address);
-    
     let transactionValue = new web3.BigNumber(value);
-    let transactionGasCost = tx.gasPrice.mul(transaction.receipt.gasUsed);
-    const transactionTotalCost = transactionValue.plus(transactionGasCost);
-    
-    assert.isTrue(contractBalanceAfter.sub(initContractBalance).eq(transactionValue), 'Contract receive sended value')
-    assert.isTrue(initBalance.minus(balanceAfter).eq(transactionTotalCost), 'User spend value + gas for transaction')
+    const tx = await web3.eth.getTransaction(transaction.tx)
+    const gasTotal = tx.gasPrice.mul(transaction.receipt.gasUsed)
+    const totalValue = gasTotal.plus(transactionValue) 
+
 
     // 2. Refund: Lock ETH to pendingRefund pool
     await instance.revertPurchase(BUYER_ADDRESS, {from: CONTRACT_CREATOR_ADDRESS, value: value});
     let balanceAfterRevert = await web3.eth.getBalance(BUYER_ADDRESS);
     let pendingRefunds = await instance.pendingRefunds_(BUYER_ADDRESS);
-
     assert.isTrue(balanceAfterRevert.eq(balanceAfter), 'ETH should be locked, not sended');
     assert.isTrue(pendingRefunds.eq(value), 'Refunds should be placed to refund pool')
 
     // 3. Withdraw all contract balance ETH, except pendingRefund value
     await instance.withdraw({from: CONTRACT_CREATOR_ADDRESS});
-    let contractAfterBalance = await web3.eth.getBalance(instance.address);
-    let totalRefunds_ = await instance.totalRefunds_.call();
-    console.log('contractAfterBalance: ', contractAfterBalance.toNumber())
-    console.log('pendingRefunds: ', pendingRefunds.toNumber())
-    assert.isTrue(contractBalanceAfter.eq(pendingRefunds),
-        'Should withdraw not more then MAX_WEI_WITHDRAWAL'
-    );
-
+    let balance = await web3.eth.getBalance(instance.address);
+    console.log('balance   : ', balance.toNumber())
+    console.log('totalValue: ', totalValue.toNumber())
+    console.log('MAX_WEI_WI:  ', MAX_WEI_WITHDRAWAL.toNumber())
+    assert.isTrue(balance.eq(totalValue), 'Should should lock refund ETH in revert pool')
     // 4. Set Finalized phase for withdraw everything:
     await instance.transition({from: CONTRACT_CREATOR_ADDRESS});
-    
     // 5. Withdraw all ETH
     await instance.withdraw({from: CONTRACT_CREATOR_ADDRESS});
     let contractFinalBalance = await web3.eth.getBalance(instance.address);
-    assert.isTrue(contractFinalBalance.eq(transactionValue),
-        'Should withdraw everything including MAX_WEI_WITHDRAWAL, but refund pending pool should left'
-    )
+    assert.isTrue(contractFinalBalance.eq(totalValue), 'Should should lock refund ETH in revert pool')
 
 });
 
-it("withdraw: It should take everything out but the X from purchase should already be gone (SendRefund sends X ETH back to purchaser)", async () => {
+it("withdraw: It should take everything out, but the X from purchase should already be gone (SendRefund sends X ETH back to purchaser)", async () => {
     // Create contract, set to Sale, must be whitelisted
     let instance = await TESTToken.new(NEUREAL_ETH_WALLET_ADDRESS, WHITELIST_PROVIDER_ADDRESS, {from: CONTRACT_CREATOR_ADDRESS, gas: deployGas, gasPrice: deployGasPrice});
     await instance.transition({from: CONTRACT_CREATOR_ADDRESS});
     await instance.whitelist(BUYER_ADDRESS, {from: WHITELIST_PROVIDER_ADDRESS});
-
     let initBalance = await web3.eth.getBalance(BUYER_ADDRESS);
     let initRefunds = await instance.pendingRefunds_(BUYER_ADDRESS);
+    let value = web3.toWei(0.01, "ether");
 
     // 1. Purchase tokens on 0.01 ETH
-    let value = web3.toWei(0.01, "ether");
     await instance.sendTransaction({from: BUYER_ADDRESS, value: value, gas: 4712388, gasPrice: 100000000000});
-    let balanceAfter = await web3.eth.getBalance(BUYER_ADDRESS);
-    assert.ok(initBalance.greaterThan(balanceAfter), 'Balance withdraw transaction cost');
-
+    let balanceAfterTransaction = await web3.eth.getBalance(BUYER_ADDRESS)
     // 2. Refund: Lock ETH to pendingRefund pool
     await instance.revertPurchase(BUYER_ADDRESS, {from: CONTRACT_CREATOR_ADDRESS, value: value});
     let balanceAfterRevert = await web3.eth.getBalance(BUYER_ADDRESS);
-    let pendingRefunds = await instance.pendingRefunds_(BUYER_ADDRESS);
 
-    assert.equal(balanceAfterRevert.toNumber(), balanceAfter.toNumber(), 'ETH should be locked, not sended');
-    assert.equal(pendingRefunds, value, 'Refunds should be placed to refund pool')
-    assert.ok(pendingRefunds.greaterThan(initRefunds), 'Pending refund is greater than initial refund state');
    
     // 3. Send refund to Buyer
     await instance.sendRefund(BUYER_ADDRESS);
     let balanceAfterRefund = await web3.eth.getBalance(BUYER_ADDRESS);
-    let finalRefunds = await instance.pendingRefunds_(BUYER_ADDRESS);
+    let refundsPool = await instance.pendingRefunds_(BUYER_ADDRESS);
 
     assert.ok(balanceAfterRefund.greaterThan(balanceAfterRevert), 'ETH should be sended back to Buyer');
-    assert.equal(initRefunds.toNumber(), finalRefunds.toNumber(), 'Refunds pool cleared');
+    assert.equal(refundsPool, 0, 'Refunds pool cleared');
 
     // 4. Withdraw all contract balance ETH, except MAX_WEI_WITHDRAWAL value
     await instance.withdraw({from: CONTRACT_CREATOR_ADDRESS});
     let contractAfterBalance = await web3.eth.getBalance(instance.address);
     let MAX_WEI_WITHDRAWAL = await instance.MAX_WEI_WITHDRAWAL.call();
     let transactionValue = new web3.BigNumber(value);
-
-    assert.equal(contractAfterBalance.toNumber(), transactionValue.sub(MAX_WEI_WITHDRAWAL).toNumber(10),
-        'Should withdraw everything, except value from revert pending pool + MAX_WEI_WITHDRAWAL'
+    console.log('contractAfterBalance: ', contractAfterBalance.toNumber())
+    assert.isTrue(contractAfterBalance.eq(0),
+        ''
     );
 
     // 5. Set Finalized phase for withdraw everything:


### PR DESCRIPTION
Tests added:
- it should take everything out after Purchase put X ETH in contract
- it should take the only amount in contract, except X from purchase which is locked in revert pool
- It should take everything out but the X from purchase should already be gone (SendRefund sends X ETH back to the purchaser)