### PR TITLE
Contract tests withdraw method

### DIFF
--- a/test/TESTTokenTest.js
+++ b/test/TESTTokenTest.js
@@ -1,48 +1,47 @@
-const TESTToken = artifacts.require("./TESTToken.sol");
+const TESTToken = artifacts.require('./TESTToken.sol');
 console.log('TESTToken.defaults:\n', TESTToken.defaults());
 
 const deployGas = 2200000;
 const deployGasPrice = 5000000000;
 
-function findEvent(res,evnt) {
-    for (let i = 0; i < res.logs.length; i++) {
-       if (res.logs[i].event == evnt) return true;
-    }
-    return false;
+function findEvent (res, evnt) {
+  for (let i = 0; i < res.logs.length; i++) {
+    if (res.logs[i].event == evnt) return true;
+  }
+  return false;
 }
 
 contract('TESTToken', async (accounts) => {
+// CONTRACT_CREATOR_ADDRESS is owner/contract creator
+  CONTRACT_CREATOR_ADDRESS = accounts[0];
+  console.log('accounts[0] owner: ', accounts[0]);
+  // accounts[1-8] is buyer
+  BUYER_ADDRESS = accounts[1];
+  console.log('accounts[1] buyer1: ', accounts[1]);
+  // accounts[8] is NEUREAL_ETH_WALLET
+  NEUREAL_ETH_WALLET_ADDRESS = accounts[8];
+  console.log('accounts[8] ETH wallet: ', accounts[8]);
+  // accounts[9] is WHITELIST_PROVIDER
+  const WHITELIST_PROVIDER_ADDRESS = accounts[9];
+  console.log('accounts[9] whitelist provider: ', accounts[9]);
 
-//CONTRACT_CREATOR_ADDRESS is owner/contract creator
-CONTRACT_CREATOR_ADDRESS = accounts[0];
-console.log('accounts[0] owner: ', accounts[0]);
-//accounts[1-8] is buyer
-BUYER_ADDRESS = accounts[1];
-console.log('accounts[1] buyer1: ', accounts[1]);
-//accounts[8] is NEUREAL_ETH_WALLET
-NEUREAL_ETH_WALLET_ADDRESS = accounts[8];
-console.log('accounts[8] ETH wallet: ', accounts[8]);
-//accounts[9] is WHITELIST_PROVIDER
-const WHITELIST_PROVIDER_ADDRESS = accounts[9];
-console.log('accounts[9] whitelist provider: ', accounts[9]);
-
-//CREATION
-it("creation: contract should deploy with less than 4.7 mil gas", async () => {
+  // CREATION
+  it('creation: contract should deploy with less than 4.7 mil gas', async () => {
     let instance = await TESTToken.new(NEUREAL_ETH_WALLET_ADDRESS, WHITELIST_PROVIDER_ADDRESS, {from: CONTRACT_CREATOR_ADDRESS, gas: deployGas, gasPrice: deployGasPrice});
 
     let receipt = await web3.eth.getTransactionReceipt(instance.transactionHash);
     console.log('Contract creation (gasUsed): ', receipt.gasUsed);
     assert.isBelow(receipt.gasUsed, 4700000);
-});
+  });
 
-it("creation: sending ether with contract deployment should revert", async () => {
+  it('creation: sending ether with contract deployment should revert', async () => {
     try {
-        var result = await TESTToken.new(NEUREAL_ETH_WALLET_ADDRESS, WHITELIST_PROVIDER_ADDRESS, {from: CONTRACT_CREATOR_ADDRESS, value: web3.toWei(0.00001, "ether"), gas: deployGas, gasPrice: deployGasPrice});
-    } catch(err) { } //console.log(err.message); }
+      var result = await TESTToken.new(NEUREAL_ETH_WALLET_ADDRESS, WHITELIST_PROVIDER_ADDRESS, {from: CONTRACT_CREATOR_ADDRESS, value: web3.toWei(0.00001, 'ether'), gas: deployGas, gasPrice: deployGasPrice});
+    } catch (err) { } // console.log(err.message); }
     assert.isUndefined(result);
-});
+  });
 
-it("creation: test correct setting of state variables", async() => {
+  it('creation: test correct setting of state variables', async () => {
     let instance = await TESTToken.new(NEUREAL_ETH_WALLET_ADDRESS, WHITELIST_PROVIDER_ADDRESS, {from: CONTRACT_CREATOR_ADDRESS, gas: deployGas, gasPrice: deployGasPrice});
 
     let OPENING_RATE = await instance.OPENING_RATE.call();
@@ -50,24 +49,24 @@ it("creation: test correct setting of state variables", async() => {
 
     let NEUREAL_ETH_WALLET = await instance.NEUREAL_ETH_WALLET.call();
     assert.strictEqual(NEUREAL_ETH_WALLET, NEUREAL_ETH_WALLET_ADDRESS);
-    
+
     let WHITELIST_PROVIDER = await instance.WHITELIST_PROVIDER.call();
     assert.strictEqual(WHITELIST_PROVIDER, WHITELIST_PROVIDER_ADDRESS);
 
     let MAX_SALE = await instance.MAX_SALE.call();
-    assert.equal(MAX_SALE, 700 * 10**18);
+    assert.equal(MAX_SALE, 700 * 10 ** 18);
 
     let MIN_PURCHASE = await instance.MIN_PURCHASE.call();
-    assert.equal(MIN_PURCHASE, 7 * 10**18);
+    assert.equal(MIN_PURCHASE, 7 * 10 ** 18);
 
     let MAX_ALLOCATION = await instance.MAX_ALLOCATION.call();
-    assert.equal(MAX_ALLOCATION, 50 * 10**18);
+    assert.equal(MAX_ALLOCATION, 50 * 10 ** 18);
 
     let MAX_SUPPLY = await instance.MAX_SUPPLY.call();
     assert.isTrue(MAX_SUPPLY.eq(MAX_SALE.add(MAX_ALLOCATION)));
 
     let MAX_WEI_WITHDRAWAL = await instance.MAX_WEI_WITHDRAWAL.call();
-    let MAX_WEI_WITHDRAWAL_test = new web3.BigNumber(70 * 10**18);
+    let MAX_WEI_WITHDRAWAL_test = new web3.BigNumber(70 * 10 ** 18);
     console.log('MAX_WEI_WITHDRAWAL: ', MAX_WEI_WITHDRAWAL_test.dividedToIntegerBy(OPENING_RATE).toString());
     assert.isTrue(MAX_WEI_WITHDRAWAL.eq(MAX_WEI_WITHDRAWAL_test.dividedToIntegerBy(OPENING_RATE)));
 
@@ -88,9 +87,9 @@ it("creation: test correct setting of state variables", async() => {
 
     let totalSupply = await instance.totalSupply.call();
     assert.equal(totalSupply, 0);
-});
+  });
 
-it("creation: test correct setting of vanity information", async() => {
+  it('creation: test correct setting of vanity information', async () => {
     let instance = await TESTToken.new(NEUREAL_ETH_WALLET_ADDRESS, WHITELIST_PROVIDER_ADDRESS, {from: CONTRACT_CREATOR_ADDRESS, gas: deployGas, gasPrice: deployGasPrice});
 
     let name = await instance.name.call();
@@ -101,104 +100,100 @@ it("creation: test correct setting of vanity information", async() => {
 
     let decimals = await instance.decimals.call();
     assert.strictEqual(decimals.toNumber(), 18);
-});
+  });
 
-it("creation: should return an initial balance of 0 token for the creator", async () => {
+  it('creation: should return an initial balance of 0 token for the creator', async () => {
     let instance = await TESTToken.new(NEUREAL_ETH_WALLET_ADDRESS, WHITELIST_PROVIDER_ADDRESS, {from: CONTRACT_CREATOR_ADDRESS, gas: deployGas, gasPrice: deployGasPrice});
 
     let estimateGas = await instance.balanceOf.estimateGas(CONTRACT_CREATOR_ADDRESS);
     console.log('balanceOf() (estimateGas): ', estimateGas);
 
     let balanceOf = await instance.balanceOf.call(CONTRACT_CREATOR_ADDRESS);
-    assert.strictEqual(balanceOf.toNumber(), 0 * 10**18);
-})
+    assert.strictEqual(balanceOf.toNumber(), 0 * 10 ** 18);
+  });
 
+  // ERC20 Transfers
 
-
-//ERC20 Transfers
-
-it("transfers: ERC20 token transfer should be reverted", async () => {
+  it('transfers: ERC20 token transfer should be reverted', async () => {
     let instance = await TESTToken.new(NEUREAL_ETH_WALLET_ADDRESS, WHITELIST_PROVIDER_ADDRESS, {from: CONTRACT_CREATOR_ADDRESS, gas: deployGas, gasPrice: deployGasPrice});
 
     try {
-        var result = await instance.transfer(BUYER_ADDRESS, 100, {from: CONTRACT_CREATOR_ADDRESS});
-    } catch(err) { } //console.log(err.message); }
+      var result = await instance.transfer(BUYER_ADDRESS, 100, {from: CONTRACT_CREATOR_ADDRESS});
+    } catch (err) { } // console.log(err.message); }
     assert.isUndefined(result);
-});
+  });
 
-//Allocate
+  // Allocate
 
-it("allocate: allocate if not owner should be reverted", async () => {
+  it('allocate: allocate if not owner should be reverted', async () => {
     let instance = await TESTToken.new(NEUREAL_ETH_WALLET_ADDRESS, WHITELIST_PROVIDER_ADDRESS, {from: CONTRACT_CREATOR_ADDRESS, gas: deployGas, gasPrice: deployGasPrice});
 
     try {
-        var result = await instance.allocate(accounts[2], 100 * 10**18, {from: BUYER_ADDRESS});
-    } catch(err) { } //console.log(err.message); }
+      var result = await instance.allocate(accounts[2], 100 * 10 ** 18, {from: BUYER_ADDRESS});
+    } catch (err) { } // console.log(err.message); }
     assert.isUndefined(result);
-});
+  });
 
-it("allocate: allocate to address zero should be reverted", async () => {
+  it('allocate: allocate to address zero should be reverted', async () => {
     let instance = await TESTToken.new(NEUREAL_ETH_WALLET_ADDRESS, WHITELIST_PROVIDER_ADDRESS, {from: CONTRACT_CREATOR_ADDRESS, gas: deployGas, gasPrice: deployGasPrice});
 
     try {
-        var result = await instance.allocate(0, 100 * 10**18, {from: CONTRACT_CREATOR_ADDRESS});
-    } catch(err) { } //console.log(err.message); }
+      var result = await instance.allocate(0, 100 * 10 ** 18, {from: CONTRACT_CREATOR_ADDRESS});
+    } catch (err) { } // console.log(err.message); }
     assert.isUndefined(result);
-});
+  });
 
-it("allocate: trying to allocate over MAX_ALLOCATION should be reverted", async () => {
+  it('allocate: trying to allocate over MAX_ALLOCATION should be reverted', async () => {
     let instance = await TESTToken.new(NEUREAL_ETH_WALLET_ADDRESS, WHITELIST_PROVIDER_ADDRESS, {from: CONTRACT_CREATOR_ADDRESS, gas: deployGas, gasPrice: deployGasPrice});
 
     let MAX_ALLOCATION = await instance.MAX_ALLOCATION.call();
     try {
-        var result = await instance.transfer(BUYER_ADDRESS, MAX_ALLOCATION.add(1), {from: CONTRACT_CREATOR_ADDRESS});
-    } catch(err) { } //console.log(err.message); }
+      var result = await instance.transfer(BUYER_ADDRESS, MAX_ALLOCATION.add(1), {from: CONTRACT_CREATOR_ADDRESS});
+    } catch (err) { } // console.log(err.message); }
     assert.isUndefined(result);
-});
+  });
 
-it("allocate: trying to allocate after state Finalized should be reverted", async () => {
+  it('allocate: trying to allocate after state Finalized should be reverted', async () => {
     let instance = await TESTToken.new(NEUREAL_ETH_WALLET_ADDRESS, WHITELIST_PROVIDER_ADDRESS, {from: CONTRACT_CREATOR_ADDRESS, gas: deployGas, gasPrice: deployGasPrice});
 
     let transition = await instance.transition({from: CONTRACT_CREATOR_ADDRESS});
     transition = await instance.transition({from: CONTRACT_CREATOR_ADDRESS});
     try {
-        var result = await instance.allocate(BUYER_ADDRESS, 5 * 10**18, {from: CONTRACT_CREATOR_ADDRESS});
-    } catch(err) { } //console.log(err.message); }
+      var result = await instance.allocate(BUYER_ADDRESS, 5 * 10 ** 18, {from: CONTRACT_CREATOR_ADDRESS});
+    } catch (err) { } // console.log(err.message); }
     assert.isUndefined(result);
-});
+  });
 
-it("allocate: should allocate 10 TEST to multiple accounts[i] and emit Transfer events", async () => {
+  it('allocate: should allocate 10 TEST to multiple accounts[i] and emit Transfer events', async () => {
     let instance = await TESTToken.new(NEUREAL_ETH_WALLET_ADDRESS, WHITELIST_PROVIDER_ADDRESS, {from: CONTRACT_CREATOR_ADDRESS, gas: deployGas, gasPrice: deployGasPrice});
 
-    let allocate = await instance.allocate(BUYER_ADDRESS, 10 * 10**18, {from: CONTRACT_CREATOR_ADDRESS});
+    let allocate = await instance.allocate(BUYER_ADDRESS, 10 * 10 ** 18, {from: CONTRACT_CREATOR_ADDRESS});
     console.log('allocate (gasUsed): ', allocate.receipt.gasUsed);
-    assert.isTrue(findEvent(allocate,"Transfer"));
+    assert.isTrue(findEvent(allocate, 'Transfer'));
     let balanceOf = await instance.balanceOf.call(BUYER_ADDRESS);
-    assert.strictEqual(balanceOf.toNumber(), 10 * 10**18);
-    
+    assert.strictEqual(balanceOf.toNumber(), 10 * 10 ** 18);
+
     for (let i = 2; i < 6; i++) {
-        let allocate = await instance.allocate(accounts[i], 10 * 10**18, {from: CONTRACT_CREATOR_ADDRESS});
-        assert.isTrue(findEvent(allocate,"Transfer"));
-        let balanceOf = await instance.balanceOf.call(accounts[i]);
-        assert.strictEqual(balanceOf.toNumber(), 10 * 10**18);
+      let allocate = await instance.allocate(accounts[i], 10 * 10 ** 18, {from: CONTRACT_CREATOR_ADDRESS});
+      assert.isTrue(findEvent(allocate, 'Transfer'));
+      let balanceOf = await instance.balanceOf.call(accounts[i]);
+      assert.strictEqual(balanceOf.toNumber(), 10 * 10 ** 18);
     }
-});
+  });
 
+  // SPECIAL
+  // test special functions
 
-
-//SPECIAL
-//test special functions
-
-it("transition: non-owner trying to call transition function should be reverted", async () => {
+  it('transition: non-owner trying to call transition function should be reverted', async () => {
     let instance = await TESTToken.new(NEUREAL_ETH_WALLET_ADDRESS, WHITELIST_PROVIDER_ADDRESS, {from: CONTRACT_CREATOR_ADDRESS, gas: deployGas, gasPrice: deployGasPrice});
 
     try {
-        var result = await instance.transition({from: BUYER_ADDRESS});
-    } catch(err) { } //console.log(err.message); }
+      var result = await instance.transition({from: BUYER_ADDRESS});
+    } catch (err) { } // console.log(err.message); }
     assert.isUndefined(result);
-});
+  });
 
-it("transition: should cycle state from BeforeSale to Sale to Finalized using transition function, then revert on 3rd time", async () => {
+  it('transition: should cycle state from BeforeSale to Sale to Finalized using transition function, then revert on 3rd time', async () => {
     let instance = await TESTToken.new(NEUREAL_ETH_WALLET_ADDRESS, WHITELIST_PROVIDER_ADDRESS, {from: CONTRACT_CREATOR_ADDRESS, gas: deployGas, gasPrice: deployGasPrice});
 
     let phase = await instance.phase.call();
@@ -213,75 +208,73 @@ it("transition: should cycle state from BeforeSale to Sale to Finalized using tr
     assert.strictEqual(phase.toString(10), '2');
 
     try {
-        var result = await instance.transition({from: CONTRACT_CREATOR_ADDRESS});
-    } catch(err) { } //console.log(err.message); }
+      var result = await instance.transition({from: CONTRACT_CREATOR_ADDRESS});
+    } catch (err) { } // console.log(err.message); }
     assert.isUndefined(result);
+  });
 
-});
-
-it("whitelist: non WHITELIST_PROVIDER trying to call whitelist function should be reverted", async () => {
+  it('whitelist: non WHITELIST_PROVIDER trying to call whitelist function should be reverted', async () => {
     let instance = await TESTToken.new(NEUREAL_ETH_WALLET_ADDRESS, WHITELIST_PROVIDER_ADDRESS, {from: CONTRACT_CREATOR_ADDRESS, gas: deployGas, gasPrice: deployGasPrice});
 
     try {
-        var result = await instance.whitelist(BUYER_ADDRESS, {from: CONTRACT_CREATOR_ADDRESS});
-    } catch(err) { } //console.log(err.message); }
+      var result = await instance.whitelist(BUYER_ADDRESS, {from: CONTRACT_CREATOR_ADDRESS});
+    } catch (err) { } // console.log(err.message); }
     assert.isUndefined(result);
-});
+  });
 
-it("whitelist: should add address to whitelist", async () => {
+  it('whitelist: should add address to whitelist', async () => {
     let instance = await TESTToken.new(NEUREAL_ETH_WALLET_ADDRESS, WHITELIST_PROVIDER_ADDRESS, {from: CONTRACT_CREATOR_ADDRESS, gas: deployGas, gasPrice: deployGasPrice});
 
     let whitelist = await instance.whitelist(BUYER_ADDRESS, {from: WHITELIST_PROVIDER_ADDRESS});
     let result = await instance.whitelisted(BUYER_ADDRESS);
     assert.isTrue(result);
-});
+  });
 
+  // Purchase
 
-//Purchase
-
-it("purchase: trying to purchase over MAX_SALE should be reverted", async () => {
+  it('purchase: trying to purchase over MAX_SALE should be reverted', async () => {
     let instance = await TESTToken.new(NEUREAL_ETH_WALLET_ADDRESS, WHITELIST_PROVIDER_ADDRESS, {from: CONTRACT_CREATOR_ADDRESS, gas: deployGas, gasPrice: deployGasPrice});
 
-    let transition = await instance.transition({from: CONTRACT_CREATOR_ADDRESS}); //set to Sale
-    let whitelist = await instance.whitelist(BUYER_ADDRESS, {from: WHITELIST_PROVIDER_ADDRESS}); //must be whitelisted
+    let transition = await instance.transition({from: CONTRACT_CREATOR_ADDRESS}); // set to Sale
+    let whitelist = await instance.whitelist(BUYER_ADDRESS, {from: WHITELIST_PROVIDER_ADDRESS}); // must be whitelisted
 
     let MAX_SALE = await instance.MAX_SALE.call();
     let OPENING_RATE = await instance.OPENING_RATE.call();
-    let value = MAX_SALE.dividedToIntegerBy(OPENING_RATE).add(1) ; //Amount to purchase with
+    let value = MAX_SALE.dividedToIntegerBy(OPENING_RATE).add(1); // Amount to purchase with
     try {
-        var result = await instance.sendTransaction({from: BUYER_ADDRESS, value: value, gas: 4712388, gasPrice: 100000000000});
-    } catch(err) { } //console.log(err.message); }
+      var result = await instance.sendTransaction({from: BUYER_ADDRESS, value: value, gas: 4712388, gasPrice: 100000000000});
+    } catch (err) { } // console.log(err.message); }
     assert.isUndefined(result);
-});
+  });
 
-it("purchase: should purchase token by sending ether to contract fallback function", async () => {
+  it('purchase: should purchase token by sending ether to contract fallback function', async () => {
     let instance = await TESTToken.new(NEUREAL_ETH_WALLET_ADDRESS, WHITELIST_PROVIDER_ADDRESS, {from: CONTRACT_CREATOR_ADDRESS, gas: deployGas, gasPrice: deployGasPrice});
 
-    let transition = await instance.transition({from: CONTRACT_CREATOR_ADDRESS}); //set to Sale
-    let whitelist = await instance.whitelist(BUYER_ADDRESS, {from: WHITELIST_PROVIDER_ADDRESS}); //must be whitelisted
-    
-    let value = web3.toWei(0.01, "ether"); //Amount to purchase with
+    let transition = await instance.transition({from: CONTRACT_CREATOR_ADDRESS}); // set to Sale
+    let whitelist = await instance.whitelist(BUYER_ADDRESS, {from: WHITELIST_PROVIDER_ADDRESS}); // must be whitelisted
+
+    let value = web3.toWei(0.01, 'ether'); // Amount to purchase with
     var purchase = await instance.sendTransaction({from: BUYER_ADDRESS, value: value, gas: 4712388, gasPrice: 100000000000});
     console.log('purchase (gasUsed): ', purchase.receipt.gasUsed);
-    assert.isTrue(findEvent(purchase,"Transfer"));
-    assert.isTrue(findEvent(purchase,"TokenPurchase"));
-    
+    assert.isTrue(findEvent(purchase, 'Transfer'));
+    assert.isTrue(findEvent(purchase, 'TokenPurchase'));
+
     let OPENING_RATE = await instance.OPENING_RATE.call();
     let balanceOf = await instance.balanceOf.call(BUYER_ADDRESS);
     // console.log('balanceOf: ', balanceOf.toString(10));
     // console.log('buy: ', OPENING_RATE.times(value).toString(10));
     assert.isTrue(balanceOf.eq(OPENING_RATE.times(value)));
-});
+  });
 
-it("withdrawl: should withdrawl all ether in the contract up to MAX_WEI_WITHDRAWAL", async () => {
+  it('withdrawl: should withdrawl all ether in the contract up to MAX_WEI_WITHDRAWAL', async () => {
     let instance = await TESTToken.new(NEUREAL_ETH_WALLET_ADDRESS, WHITELIST_PROVIDER_ADDRESS, {from: CONTRACT_CREATOR_ADDRESS, gas: deployGas, gasPrice: deployGasPrice});
 
-    let transition = await instance.transition({from: CONTRACT_CREATOR_ADDRESS}); //set to Sale
-    let whitelist = await instance.whitelist(BUYER_ADDRESS, {from: WHITELIST_PROVIDER_ADDRESS}); //must be whitelisted
-    
-    let value = web3.toWei(0.01, "ether"); //Amount to purchase with
+    let transition = await instance.transition({from: CONTRACT_CREATOR_ADDRESS}); // set to Sale
+    let whitelist = await instance.whitelist(BUYER_ADDRESS, {from: WHITELIST_PROVIDER_ADDRESS}); // must be whitelisted
+
+    let value = web3.toWei(0.01, 'ether'); // Amount to purchase with
     var purchase = await instance.sendTransaction({from: BUYER_ADDRESS, value: value, gas: 4712388, gasPrice: 100000000000});
-    
+
     let balance_before = await web3.eth.getBalance(instance.address);
     console.log('before withdraw: balance[%s]', balance_before.toString(10));
 
@@ -292,18 +285,18 @@ it("withdrawl: should withdrawl all ether in the contract up to MAX_WEI_WITHDRAW
 
     let MAX_WEI_WITHDRAWAL = await instance.MAX_WEI_WITHDRAWAL.call();
     assert.isTrue(MAX_WEI_WITHDRAWAL.eq(balance_before.sub(balance_after)));
-});
+  });
 
-//Revert
+  // Revert
 
-it("revert: should refund ETH and return allocated token to pool", async () => {
+  it('revert: should refund ETH and return allocated token to pool', async () => {
     let instance = await TESTToken.new(NEUREAL_ETH_WALLET_ADDRESS, WHITELIST_PROVIDER_ADDRESS, {from: CONTRACT_CREATOR_ADDRESS, gas: deployGas, gasPrice: deployGasPrice});
-    
+
     let OPENING_RATE = await instance.OPENING_RATE.call();
 
-    let transition = await instance.transition({from: CONTRACT_CREATOR_ADDRESS}); //set to Sale
-    let whitelist = await instance.whitelist(BUYER_ADDRESS, {from: WHITELIST_PROVIDER_ADDRESS}); //must be whitelisted
-    
+    let transition = await instance.transition({from: CONTRACT_CREATOR_ADDRESS}); // set to Sale
+    let whitelist = await instance.whitelist(BUYER_ADDRESS, {from: WHITELIST_PROVIDER_ADDRESS}); // must be whitelisted
+
     let totalSupply = await instance.totalSupply.call();
     let totalSale = await instance.totalSale.call();
     let balanceOf = await instance.balanceOf.call(BUYER_ADDRESS);
@@ -311,14 +304,14 @@ it("revert: should refund ETH and return allocated token to pool", async () => {
     let balance = await web3.eth.getBalance(instance.address);
     let totalRefunds_ = await instance.totalRefunds_.call();
     console.log('before purchase: total_token[%s] sale_token[%s] buyer_token[%s]   tracked_contract_wei[%s] actual_contract_wei[%s] locked_refund_wei[%s]',
-        totalSupply.toString(10), totalSale.toString(10), balanceOf.toString(10), totalWei.toString(10), balance.toString(10), totalRefunds_.toString(10));
-    
+      totalSupply.toString(10), totalSale.toString(10), balanceOf.toString(10), totalWei.toString(10), balance.toString(10), totalRefunds_.toString(10));
+
 
     // purchase
-    let value = web3.toWei(0.01, "ether"); //Amount to purchase with
+    let value = web3.toWei(0.01, 'ether'); // Amount to purchase with
     var purchase = await instance.sendTransaction({from: BUYER_ADDRESS, value: value, gas: 4712388, gasPrice: 100000000000});
-    assert.isTrue(findEvent(purchase,"Transfer"));
-    assert.isTrue(findEvent(purchase,"TokenPurchase"));
+    assert.isTrue(findEvent(purchase, 'Transfer'));
+    assert.isTrue(findEvent(purchase, 'TokenPurchase'));
 
     totalSupply = await instance.totalSupply.call();
     totalSale = await instance.totalSale.call();
@@ -327,16 +320,15 @@ it("revert: should refund ETH and return allocated token to pool", async () => {
     balance = await web3.eth.getBalance(instance.address);
     totalRefunds_ = await instance.totalRefunds_.call();
     console.log('before refund: total_token[%s] sale_token[%s] buyer_token[%s]   tracked_contract_wei[%s] actual_contract_wei[%s] locked_refund_wei[%s]',
-        totalSupply.toString(10), totalSale.toString(10), balanceOf.toString(10), totalWei.toString(10), balance.toString(10), totalRefunds_.toString(10));
-    
+      totalSupply.toString(10), totalSale.toString(10), balanceOf.toString(10), totalWei.toString(10), balance.toString(10), totalRefunds_.toString(10));
+
     // console.log('buy: ', OPENING_RATE.times(value).toString(10));
     assert.isTrue(balanceOf.eq(OPENING_RATE.times(value)));
 
-
     // revert
-    let revert = await instance.revertPurchase(BUYER_ADDRESS, {from: CONTRACT_CREATOR_ADDRESS, value: value, gas: 4712388, gasPrice: 100000000000}); //execute revert
+    let revert = await instance.revertPurchase(BUYER_ADDRESS, {from: CONTRACT_CREATOR_ADDRESS, value: value, gas: 4712388, gasPrice: 100000000000}); // execute revert
     console.log('revertPurchase (gasUsed): ', revert.receipt.gasUsed);
-    assert.isTrue(findEvent(revert,"Transfer"));
+    assert.isTrue(findEvent(revert, 'Transfer'));
 
     totalSupply = await instance.totalSupply.call();
     totalSale = await instance.totalSale.call();
@@ -345,18 +337,17 @@ it("revert: should refund ETH and return allocated token to pool", async () => {
     balance = await web3.eth.getBalance(instance.address);
     totalRefunds_ = await instance.totalRefunds_.call();
     console.log('after revert: total_token[%s] sale_token[%s] buyer_token[%s]   tracked_contract_wei[%s] actual_contract_wei[%s] locked_refund_wei[%s]',
-        totalSupply.toString(10), totalSale.toString(10), balanceOf.toString(10), totalWei.toString(10), balance.toString(10), totalRefunds_.toString(10));
-    
+      totalSupply.toString(10), totalSale.toString(10), balanceOf.toString(10), totalWei.toString(10), balance.toString(10), totalRefunds_.toString(10));
+
     assert.isTrue(balanceOf.eq(0));
+  });
 
-});
-
-it("withdraw: should take everything out after Purchase put X ETH in contract", async () => {
+  it('withdraw: should take everything out after Purchase put X ETH in contract', async () => {
     // 0. Create contract, set to Sale, must be whitelisted
     let instance = await TESTToken.new(NEUREAL_ETH_WALLET_ADDRESS, WHITELIST_PROVIDER_ADDRESS, {from: CONTRACT_CREATOR_ADDRESS, gas: deployGas, gasPrice: deployGasPrice});
     await instance.transition({from: CONTRACT_CREATOR_ADDRESS});
     await instance.whitelist(BUYER_ADDRESS, {from: WHITELIST_PROVIDER_ADDRESS});
-    let value = web3.toWei(0.01, "ether");
+    let value = web3.toWei(0.01, 'ether');
     // 1. Purchase tokens on 0.01 ETH
     await instance.sendTransaction({from: BUYER_ADDRESS, value: value});
     // 2. Withdraw all contract balance ETH, except MAX_WEI_WITHDRAWAL value
@@ -368,15 +359,15 @@ it("withdraw: should take everything out after Purchase put X ETH in contract", 
     await instance.withdraw({from: CONTRACT_CREATOR_ADDRESS});
     contractBalance = web3.eth.getBalance(instance.address);
     // All eth was withdrawerd from contract balance:
-    assert.equal(contractBalance, 0)
-});
+    assert.equal(contractBalance, 0);
+  });
 
-it("withdraw: it should take only amount in contract, except X from purchase which is locked in revert pool", async () => {
+  it('withdraw: it should take only amount in contract, except X from purchase which is locked in revert pool', async () => {
     // 0. Create contract, set to Sale, must be whitelisted
     let instance = await TESTToken.new(NEUREAL_ETH_WALLET_ADDRESS, WHITELIST_PROVIDER_ADDRESS, {from: CONTRACT_CREATOR_ADDRESS, gas: deployGas, gasPrice: deployGasPrice});
     await instance.transition({from: CONTRACT_CREATOR_ADDRESS});
     await instance.whitelist(BUYER_ADDRESS, {from: WHITELIST_PROVIDER_ADDRESS});
-    let value = web3.toWei(0.01, "ether");
+    let value = web3.toWei(0.01, 'ether');
     // 1. Purchase tokens on 0.01 ETH
     await instance.sendTransaction({from: BUYER_ADDRESS, value: value});
     // 2. Refund: Lock ETH to pendingRefund pool
@@ -388,34 +379,34 @@ it("withdraw: it should take only amount in contract, except X from purchase whi
     // 5. Withdraw all ETH
     await instance.withdraw({from: CONTRACT_CREATOR_ADDRESS});
     let contractBalance = web3.eth.getBalance(instance.address);
-    const bigValue = web3.toBigNumber(value)
+    const bigValue = web3.toBigNumber(value);
     // Withdraw everything except
-    assert.isTrue(contractBalance.eq(bigValue))
+    assert.isTrue(contractBalance.eq(bigValue));
     // 6. Send refund after
     await instance.sendRefund(BUYER_ADDRESS);
     contractBalance = web3.eth.getBalance(instance.address);
-    assert.equal(contractBalance, 0)
-});
+    assert.equal(contractBalance, 0);
+  });
 
-it("withdraw: It should take everything out, but the X from purchase should already be gone (SendRefund sends X ETH back to purchaser)", async () => {
+  it('withdraw: It should take everything out, but the X from purchase should already be gone (SendRefund sends X ETH back to purchaser)', async () => {
     // 0. Create contract, set to Sale, must be whitelisted
     let instance = await TESTToken.new(NEUREAL_ETH_WALLET_ADDRESS, WHITELIST_PROVIDER_ADDRESS, {from: CONTRACT_CREATOR_ADDRESS, gas: deployGas, gasPrice: deployGasPrice});
     await instance.transition({from: CONTRACT_CREATOR_ADDRESS});
     await instance.whitelist(BUYER_ADDRESS, {from: WHITELIST_PROVIDER_ADDRESS});
 
-    let value = web3.toWei(0.01, "ether");
-    const bigValue = web3.toBigNumber(value)
+    let value = web3.toWei(0.01, 'ether');
+    const bigValue = web3.toBigNumber(value);
     // 1. Purchase tokens on 0.01 ETH
     await instance.sendTransaction({from: BUYER_ADDRESS, value: value});
     // 2. Refund: Lock ETH to pendingRefund pool
     await instance.revertPurchase(BUYER_ADDRESS, {from: CONTRACT_CREATOR_ADDRESS, value: value});
     let totalRefunds_ = await instance.totalRefunds_.call();
-    assert.isTrue(totalRefunds_.eq(bigValue), 'Check refund pool')
+    assert.isTrue(totalRefunds_.eq(bigValue), 'Check refund pool');
     // 3. Send refund to Buyer
     const balanceBefore = web3.eth.getBalance(instance.address);
     await instance.sendRefund(BUYER_ADDRESS);
     const balanceAfter = web3.eth.getBalance(instance.address);
-    assert.isTrue(balanceAfter.eq(balanceBefore.sub(bigValue)), 'Refund money should already be gone')
+    assert.isTrue(balanceAfter.eq(balanceBefore.sub(bigValue)), 'Refund money should already be gone');
     // 4. Withdraw all contract balance ETH, except MAX_WEI_WITHDRAWAL value
     await instance.withdraw({from: CONTRACT_CREATOR_ADDRESS});
     // 5. Set Finalized phase for withdraw everything:
@@ -423,7 +414,6 @@ it("withdraw: It should take everything out, but the X from purchase should alre
     // 6. Withdraw all ETH
     await instance.withdraw({from: CONTRACT_CREATOR_ADDRESS});
     let contractBalance = web3.eth.getBalance(instance.address);
-    assert.equal(contractBalance, 0)
-});
-
+    assert.equal(contractBalance, 0);
+  });
 });

--- a/test/TESTTokenTest.js
+++ b/test/TESTTokenTest.js
@@ -13,23 +13,22 @@ function findEvent(res,evnt) {
 
 contract('TESTToken', async (accounts) => {
 
-//accounts[0] is owner/contract creator
+//CONTRACT_CREATOR_ADDRESS is owner/contract creator
+CONTRACT_CREATOR_ADDRESS = accounts[0];
 console.log('accounts[0] owner: ', accounts[0]);
 //accounts[1-8] is buyer
+BUYER_ADDRESS = accounts[1];
 console.log('accounts[1] buyer1: ', accounts[1]);
 //accounts[8] is NEUREAL_ETH_WALLET
+NEUREAL_ETH_WALLET_ADDRESS = accounts[8];
 console.log('accounts[8] ETH wallet: ', accounts[8]);
 //accounts[9] is WHITELIST_PROVIDER
+const WHITELIST_PROVIDER_ADDRESS = accounts[9];
 console.log('accounts[9] whitelist provider: ', accounts[9]);
 
-// let receipt = await web3.eth.sendTransaction({from: accounts[0], to: accounts[1], value: web3.toWei(1.0, "ether"), gas: 4712388, gasPrice: 100000000000});
-// console.log('receipt: ', receipt);
-
-
 //CREATION
-
 it("creation: contract should deploy with less than 4.7 mil gas", async () => {
-    let instance = await TESTToken.new(accounts[8], accounts[9], {from: accounts[0], gas: deployGas, gasPrice: deployGasPrice});
+    let instance = await TESTToken.new(NEUREAL_ETH_WALLET_ADDRESS, WHITELIST_PROVIDER_ADDRESS, {from: CONTRACT_CREATOR_ADDRESS, gas: deployGas, gasPrice: deployGasPrice});
 
     let receipt = await web3.eth.getTransactionReceipt(instance.transactionHash);
     console.log('Contract creation (gasUsed): ', receipt.gasUsed);
@@ -38,22 +37,22 @@ it("creation: contract should deploy with less than 4.7 mil gas", async () => {
 
 it("creation: sending ether with contract deployment should revert", async () => {
     try {
-        var result = await TESTToken.new(accounts[8], accounts[9], {from: accounts[0], value: web3.toWei(0.00001, "ether"), gas: deployGas, gasPrice: deployGasPrice});
+        var result = await TESTToken.new(NEUREAL_ETH_WALLET_ADDRESS, WHITELIST_PROVIDER_ADDRESS, {from: CONTRACT_CREATOR_ADDRESS, value: web3.toWei(0.00001, "ether"), gas: deployGas, gasPrice: deployGasPrice});
     } catch(err) { } //console.log(err.message); }
     assert.isUndefined(result);
 });
 
 it("creation: test correct setting of state variables", async() => {
-    let instance = await TESTToken.new(accounts[8], accounts[9], {from: accounts[0], gas: deployGas, gasPrice: deployGasPrice});
+    let instance = await TESTToken.new(NEUREAL_ETH_WALLET_ADDRESS, WHITELIST_PROVIDER_ADDRESS, {from: CONTRACT_CREATOR_ADDRESS, gas: deployGas, gasPrice: deployGasPrice});
 
     let OPENING_RATE = await instance.OPENING_RATE.call();
     assert.equal(OPENING_RATE, 7143);
 
     let NEUREAL_ETH_WALLET = await instance.NEUREAL_ETH_WALLET.call();
-    assert.strictEqual(NEUREAL_ETH_WALLET, accounts[8]);
+    assert.strictEqual(NEUREAL_ETH_WALLET, NEUREAL_ETH_WALLET_ADDRESS);
     
     let WHITELIST_PROVIDER = await instance.WHITELIST_PROVIDER.call();
-    assert.strictEqual(WHITELIST_PROVIDER, accounts[9]);
+    assert.strictEqual(WHITELIST_PROVIDER, WHITELIST_PROVIDER_ADDRESS);
 
     let MAX_SALE = await instance.MAX_SALE.call();
     assert.equal(MAX_SALE, 700 * 10**18);
@@ -73,7 +72,7 @@ it("creation: test correct setting of state variables", async() => {
     assert.isTrue(MAX_WEI_WITHDRAWAL.eq(MAX_WEI_WITHDRAWAL_test.dividedToIntegerBy(OPENING_RATE)));
 
     let owner_ = await instance.owner.call();
-    assert.strictEqual(owner_, accounts[0]);
+    assert.strictEqual(owner_, CONTRACT_CREATOR_ADDRESS);
 
     let totalSale = await instance.totalSale.call();
     assert.equal(totalSale, 0);
@@ -92,7 +91,7 @@ it("creation: test correct setting of state variables", async() => {
 });
 
 it("creation: test correct setting of vanity information", async() => {
-    let instance = await TESTToken.new(accounts[8], accounts[9], {from: accounts[0], gas: deployGas, gasPrice: deployGasPrice});
+    let instance = await TESTToken.new(NEUREAL_ETH_WALLET_ADDRESS, WHITELIST_PROVIDER_ADDRESS, {from: CONTRACT_CREATOR_ADDRESS, gas: deployGas, gasPrice: deployGasPrice});
 
     let name = await instance.name.call();
     assert.strictEqual(name, 'Neureal TGE Test');
@@ -105,12 +104,12 @@ it("creation: test correct setting of vanity information", async() => {
 });
 
 it("creation: should return an initial balance of 0 token for the creator", async () => {
-    let instance = await TESTToken.new(accounts[8], accounts[9], {from: accounts[0], gas: deployGas, gasPrice: deployGasPrice});
+    let instance = await TESTToken.new(NEUREAL_ETH_WALLET_ADDRESS, WHITELIST_PROVIDER_ADDRESS, {from: CONTRACT_CREATOR_ADDRESS, gas: deployGas, gasPrice: deployGasPrice});
 
-    let estimateGas = await instance.balanceOf.estimateGas(accounts[0]);
+    let estimateGas = await instance.balanceOf.estimateGas(CONTRACT_CREATOR_ADDRESS);
     console.log('balanceOf() (estimateGas): ', estimateGas);
 
-    let balanceOf = await instance.balanceOf.call(accounts[0]);
+    let balanceOf = await instance.balanceOf.call(CONTRACT_CREATOR_ADDRESS);
     assert.strictEqual(balanceOf.toNumber(), 0 * 10**18);
 })
 
@@ -119,10 +118,10 @@ it("creation: should return an initial balance of 0 token for the creator", asyn
 //ERC20 Transfers
 
 it("transfers: ERC20 token transfer should be reverted", async () => {
-    let instance = await TESTToken.new(accounts[8], accounts[9], {from: accounts[0], gas: deployGas, gasPrice: deployGasPrice});
+    let instance = await TESTToken.new(NEUREAL_ETH_WALLET_ADDRESS, WHITELIST_PROVIDER_ADDRESS, {from: CONTRACT_CREATOR_ADDRESS, gas: deployGas, gasPrice: deployGasPrice});
 
     try {
-        var result = await instance.transfer(accounts[1], 100, {from: accounts[0]});
+        var result = await instance.transfer(BUYER_ADDRESS, 100, {from: CONTRACT_CREATOR_ADDRESS});
     } catch(err) { } //console.log(err.message); }
     assert.isUndefined(result);
 });
@@ -130,55 +129,55 @@ it("transfers: ERC20 token transfer should be reverted", async () => {
 //Allocate
 
 it("allocate: allocate if not owner should be reverted", async () => {
-    let instance = await TESTToken.new(accounts[8], accounts[9], {from: accounts[0], gas: deployGas, gasPrice: deployGasPrice});
+    let instance = await TESTToken.new(NEUREAL_ETH_WALLET_ADDRESS, WHITELIST_PROVIDER_ADDRESS, {from: CONTRACT_CREATOR_ADDRESS, gas: deployGas, gasPrice: deployGasPrice});
 
     try {
-        var result = await instance.allocate(accounts[2], 100 * 10**18, {from: accounts[1]});
+        var result = await instance.allocate(accounts[2], 100 * 10**18, {from: BUYER_ADDRESS});
     } catch(err) { } //console.log(err.message); }
     assert.isUndefined(result);
 });
 
 it("allocate: allocate to address zero should be reverted", async () => {
-    let instance = await TESTToken.new(accounts[8], accounts[9], {from: accounts[0], gas: deployGas, gasPrice: deployGasPrice});
+    let instance = await TESTToken.new(NEUREAL_ETH_WALLET_ADDRESS, WHITELIST_PROVIDER_ADDRESS, {from: CONTRACT_CREATOR_ADDRESS, gas: deployGas, gasPrice: deployGasPrice});
 
     try {
-        var result = await instance.allocate(0, 100 * 10**18, {from: accounts[0]});
+        var result = await instance.allocate(0, 100 * 10**18, {from: CONTRACT_CREATOR_ADDRESS});
     } catch(err) { } //console.log(err.message); }
     assert.isUndefined(result);
 });
 
 it("allocate: trying to allocate over MAX_ALLOCATION should be reverted", async () => {
-    let instance = await TESTToken.new(accounts[8], accounts[9], {from: accounts[0], gas: deployGas, gasPrice: deployGasPrice});
+    let instance = await TESTToken.new(NEUREAL_ETH_WALLET_ADDRESS, WHITELIST_PROVIDER_ADDRESS, {from: CONTRACT_CREATOR_ADDRESS, gas: deployGas, gasPrice: deployGasPrice});
 
     let MAX_ALLOCATION = await instance.MAX_ALLOCATION.call();
     try {
-        var result = await instance.transfer(accounts[1], MAX_ALLOCATION.add(1), {from: accounts[0]});
+        var result = await instance.transfer(BUYER_ADDRESS, MAX_ALLOCATION.add(1), {from: CONTRACT_CREATOR_ADDRESS});
     } catch(err) { } //console.log(err.message); }
     assert.isUndefined(result);
 });
 
 it("allocate: trying to allocate after state Finalized should be reverted", async () => {
-    let instance = await TESTToken.new(accounts[8], accounts[9], {from: accounts[0], gas: deployGas, gasPrice: deployGasPrice});
+    let instance = await TESTToken.new(NEUREAL_ETH_WALLET_ADDRESS, WHITELIST_PROVIDER_ADDRESS, {from: CONTRACT_CREATOR_ADDRESS, gas: deployGas, gasPrice: deployGasPrice});
 
-    let transition = await instance.transition({from: accounts[0]});
-    transition = await instance.transition({from: accounts[0]});
+    let transition = await instance.transition({from: CONTRACT_CREATOR_ADDRESS});
+    transition = await instance.transition({from: CONTRACT_CREATOR_ADDRESS});
     try {
-        var result = await instance.allocate(accounts[1], 5 * 10**18, {from: accounts[0]});
+        var result = await instance.allocate(BUYER_ADDRESS, 5 * 10**18, {from: CONTRACT_CREATOR_ADDRESS});
     } catch(err) { } //console.log(err.message); }
     assert.isUndefined(result);
 });
 
 it("allocate: should allocate 10 TEST to multiple accounts[i] and emit Transfer events", async () => {
-    let instance = await TESTToken.new(accounts[8], accounts[9], {from: accounts[0], gas: deployGas, gasPrice: deployGasPrice});
+    let instance = await TESTToken.new(NEUREAL_ETH_WALLET_ADDRESS, WHITELIST_PROVIDER_ADDRESS, {from: CONTRACT_CREATOR_ADDRESS, gas: deployGas, gasPrice: deployGasPrice});
 
-    let allocate = await instance.allocate(accounts[1], 10 * 10**18, {from: accounts[0]});
+    let allocate = await instance.allocate(BUYER_ADDRESS, 10 * 10**18, {from: CONTRACT_CREATOR_ADDRESS});
     console.log('allocate (gasUsed): ', allocate.receipt.gasUsed);
     assert.isTrue(findEvent(allocate,"Transfer"));
-    let balanceOf = await instance.balanceOf.call(accounts[1]);
+    let balanceOf = await instance.balanceOf.call(BUYER_ADDRESS);
     assert.strictEqual(balanceOf.toNumber(), 10 * 10**18);
     
     for (let i = 2; i < 6; i++) {
-        let allocate = await instance.allocate(accounts[i], 10 * 10**18, {from: accounts[0]});
+        let allocate = await instance.allocate(accounts[i], 10 * 10**18, {from: CONTRACT_CREATOR_ADDRESS});
         assert.isTrue(findEvent(allocate,"Transfer"));
         let balanceOf = await instance.balanceOf.call(accounts[i]);
         assert.strictEqual(balanceOf.toNumber(), 10 * 10**18);
@@ -191,49 +190,49 @@ it("allocate: should allocate 10 TEST to multiple accounts[i] and emit Transfer 
 //test special functions
 
 it("transition: non-owner trying to call transition function should be reverted", async () => {
-    let instance = await TESTToken.new(accounts[8], accounts[9], {from: accounts[0], gas: deployGas, gasPrice: deployGasPrice});
+    let instance = await TESTToken.new(NEUREAL_ETH_WALLET_ADDRESS, WHITELIST_PROVIDER_ADDRESS, {from: CONTRACT_CREATOR_ADDRESS, gas: deployGas, gasPrice: deployGasPrice});
 
     try {
-        var result = await instance.transition({from: accounts[1]});
+        var result = await instance.transition({from: BUYER_ADDRESS});
     } catch(err) { } //console.log(err.message); }
     assert.isUndefined(result);
 });
 
 it("transition: should cycle state from BeforeSale to Sale to Finalized using transition function, then revert on 3rd time", async () => {
-    let instance = await TESTToken.new(accounts[8], accounts[9], {from: accounts[0], gas: deployGas, gasPrice: deployGasPrice});
+    let instance = await TESTToken.new(NEUREAL_ETH_WALLET_ADDRESS, WHITELIST_PROVIDER_ADDRESS, {from: CONTRACT_CREATOR_ADDRESS, gas: deployGas, gasPrice: deployGasPrice});
 
     let phase = await instance.phase.call();
     assert.strictEqual(phase.toString(10), '0');
 
-    let transition = await instance.transition({from: accounts[0]});
+    let transition = await instance.transition({from: CONTRACT_CREATOR_ADDRESS});
     phase = await instance.phase.call();
     assert.strictEqual(phase.toString(10), '1');
 
-    transition = await instance.transition({from: accounts[0]});
+    transition = await instance.transition({from: CONTRACT_CREATOR_ADDRESS});
     phase = await instance.phase.call();
     assert.strictEqual(phase.toString(10), '2');
 
     try {
-        var result = await instance.transition({from: accounts[0]});
+        var result = await instance.transition({from: CONTRACT_CREATOR_ADDRESS});
     } catch(err) { } //console.log(err.message); }
     assert.isUndefined(result);
 
 });
 
 it("whitelist: non WHITELIST_PROVIDER trying to call whitelist function should be reverted", async () => {
-    let instance = await TESTToken.new(accounts[8], accounts[9], {from: accounts[0], gas: deployGas, gasPrice: deployGasPrice});
+    let instance = await TESTToken.new(NEUREAL_ETH_WALLET_ADDRESS, WHITELIST_PROVIDER_ADDRESS, {from: CONTRACT_CREATOR_ADDRESS, gas: deployGas, gasPrice: deployGasPrice});
 
     try {
-        var result = await instance.whitelist(accounts[1], {from: accounts[0]});
+        var result = await instance.whitelist(BUYER_ADDRESS, {from: CONTRACT_CREATOR_ADDRESS});
     } catch(err) { } //console.log(err.message); }
     assert.isUndefined(result);
 });
 
 it("whitelist: should add address to whitelist", async () => {
-    let instance = await TESTToken.new(accounts[8], accounts[9], {from: accounts[0], gas: deployGas, gasPrice: deployGasPrice});
+    let instance = await TESTToken.new(NEUREAL_ETH_WALLET_ADDRESS, WHITELIST_PROVIDER_ADDRESS, {from: CONTRACT_CREATOR_ADDRESS, gas: deployGas, gasPrice: deployGasPrice});
 
-    let whitelist = await instance.whitelist(accounts[1], {from: accounts[9]});
-    let result = await instance.whitelisted(accounts[1]);
+    let whitelist = await instance.whitelist(BUYER_ADDRESS, {from: WHITELIST_PROVIDER_ADDRESS});
+    let result = await instance.whitelisted(BUYER_ADDRESS);
     assert.isTrue(result);
 });
 
@@ -241,52 +240,52 @@ it("whitelist: should add address to whitelist", async () => {
 //Purchase
 
 it("purchase: trying to purchase over MAX_SALE should be reverted", async () => {
-    let instance = await TESTToken.new(accounts[8], accounts[9], {from: accounts[0], gas: deployGas, gasPrice: deployGasPrice});
+    let instance = await TESTToken.new(NEUREAL_ETH_WALLET_ADDRESS, WHITELIST_PROVIDER_ADDRESS, {from: CONTRACT_CREATOR_ADDRESS, gas: deployGas, gasPrice: deployGasPrice});
 
-    let transition = await instance.transition({from: accounts[0]}); //set to Sale
-    let whitelist = await instance.whitelist(accounts[1], {from: accounts[9]}); //must be whitelisted
+    let transition = await instance.transition({from: CONTRACT_CREATOR_ADDRESS}); //set to Sale
+    let whitelist = await instance.whitelist(BUYER_ADDRESS, {from: WHITELIST_PROVIDER_ADDRESS}); //must be whitelisted
 
     let MAX_SALE = await instance.MAX_SALE.call();
     let OPENING_RATE = await instance.OPENING_RATE.call();
     let value = MAX_SALE.dividedToIntegerBy(OPENING_RATE).add(1) ; //Amount to purchase with
     try {
-        var result = await instance.sendTransaction({from: accounts[1], value: value, gas: 4712388, gasPrice: 100000000000});
+        var result = await instance.sendTransaction({from: BUYER_ADDRESS, value: value, gas: 4712388, gasPrice: 100000000000});
     } catch(err) { } //console.log(err.message); }
     assert.isUndefined(result);
 });
 
 it("purchase: should purchase token by sending ether to contract fallback function", async () => {
-    let instance = await TESTToken.new(accounts[8], accounts[9], {from: accounts[0], gas: deployGas, gasPrice: deployGasPrice});
+    let instance = await TESTToken.new(NEUREAL_ETH_WALLET_ADDRESS, WHITELIST_PROVIDER_ADDRESS, {from: CONTRACT_CREATOR_ADDRESS, gas: deployGas, gasPrice: deployGasPrice});
 
-    let transition = await instance.transition({from: accounts[0]}); //set to Sale
-    let whitelist = await instance.whitelist(accounts[1], {from: accounts[9]}); //must be whitelisted
+    let transition = await instance.transition({from: CONTRACT_CREATOR_ADDRESS}); //set to Sale
+    let whitelist = await instance.whitelist(BUYER_ADDRESS, {from: WHITELIST_PROVIDER_ADDRESS}); //must be whitelisted
     
     let value = web3.toWei(0.01, "ether"); //Amount to purchase with
-    var purchase = await instance.sendTransaction({from: accounts[1], value: value, gas: 4712388, gasPrice: 100000000000});
+    var purchase = await instance.sendTransaction({from: BUYER_ADDRESS, value: value, gas: 4712388, gasPrice: 100000000000});
     console.log('purchase (gasUsed): ', purchase.receipt.gasUsed);
     assert.isTrue(findEvent(purchase,"Transfer"));
     assert.isTrue(findEvent(purchase,"TokenPurchase"));
     
     let OPENING_RATE = await instance.OPENING_RATE.call();
-    let balanceOf = await instance.balanceOf.call(accounts[1]);
+    let balanceOf = await instance.balanceOf.call(BUYER_ADDRESS);
     // console.log('balanceOf: ', balanceOf.toString(10));
     // console.log('buy: ', OPENING_RATE.times(value).toString(10));
     assert.isTrue(balanceOf.eq(OPENING_RATE.times(value)));
 });
 
 it("withdrawl: should withdrawl all ether in the contract up to MAX_WEI_WITHDRAWAL", async () => {
-    let instance = await TESTToken.new(accounts[8], accounts[9], {from: accounts[0], gas: deployGas, gasPrice: deployGasPrice});
+    let instance = await TESTToken.new(NEUREAL_ETH_WALLET_ADDRESS, WHITELIST_PROVIDER_ADDRESS, {from: CONTRACT_CREATOR_ADDRESS, gas: deployGas, gasPrice: deployGasPrice});
 
-    let transition = await instance.transition({from: accounts[0]}); //set to Sale
-    let whitelist = await instance.whitelist(accounts[1], {from: accounts[9]}); //must be whitelisted
+    let transition = await instance.transition({from: CONTRACT_CREATOR_ADDRESS}); //set to Sale
+    let whitelist = await instance.whitelist(BUYER_ADDRESS, {from: WHITELIST_PROVIDER_ADDRESS}); //must be whitelisted
     
     let value = web3.toWei(0.01, "ether"); //Amount to purchase with
-    var purchase = await instance.sendTransaction({from: accounts[1], value: value, gas: 4712388, gasPrice: 100000000000});
+    var purchase = await instance.sendTransaction({from: BUYER_ADDRESS, value: value, gas: 4712388, gasPrice: 100000000000});
     
     let balance_before = await web3.eth.getBalance(instance.address);
     console.log('before withdraw: balance[%s]', balance_before.toString(10));
 
-    let withdraw = await instance.withdraw({from: accounts[0]});
+    let withdraw = await instance.withdraw({from: CONTRACT_CREATOR_ADDRESS});
 
     let balance_after = await web3.eth.getBalance(instance.address);
     console.log('after withdraw: balance[%s]', balance_after.toString(10));
@@ -298,16 +297,16 @@ it("withdrawl: should withdrawl all ether in the contract up to MAX_WEI_WITHDRAW
 //Revert
 
 it("revert: should refund ETH and return allocated token to pool", async () => {
-    let instance = await TESTToken.new(accounts[8], accounts[9], {from: accounts[0], gas: deployGas, gasPrice: deployGasPrice});
+    let instance = await TESTToken.new(NEUREAL_ETH_WALLET_ADDRESS, WHITELIST_PROVIDER_ADDRESS, {from: CONTRACT_CREATOR_ADDRESS, gas: deployGas, gasPrice: deployGasPrice});
     
     let OPENING_RATE = await instance.OPENING_RATE.call();
 
-    let transition = await instance.transition({from: accounts[0]}); //set to Sale
-    let whitelist = await instance.whitelist(accounts[1], {from: accounts[9]}); //must be whitelisted
+    let transition = await instance.transition({from: CONTRACT_CREATOR_ADDRESS}); //set to Sale
+    let whitelist = await instance.whitelist(BUYER_ADDRESS, {from: WHITELIST_PROVIDER_ADDRESS}); //must be whitelisted
     
     let totalSupply = await instance.totalSupply.call();
     let totalSale = await instance.totalSale.call();
-    let balanceOf = await instance.balanceOf.call(accounts[1]);
+    let balanceOf = await instance.balanceOf.call(BUYER_ADDRESS);
     let totalWei = await instance.totalWei.call();
     let balance = await web3.eth.getBalance(instance.address);
     let totalRefunds_ = await instance.totalRefunds_.call();
@@ -317,13 +316,13 @@ it("revert: should refund ETH and return allocated token to pool", async () => {
 
     // purchase
     let value = web3.toWei(0.01, "ether"); //Amount to purchase with
-    var purchase = await instance.sendTransaction({from: accounts[1], value: value, gas: 4712388, gasPrice: 100000000000});
+    var purchase = await instance.sendTransaction({from: BUYER_ADDRESS, value: value, gas: 4712388, gasPrice: 100000000000});
     assert.isTrue(findEvent(purchase,"Transfer"));
     assert.isTrue(findEvent(purchase,"TokenPurchase"));
 
     totalSupply = await instance.totalSupply.call();
     totalSale = await instance.totalSale.call();
-    balanceOf = await instance.balanceOf.call(accounts[1]);
+    balanceOf = await instance.balanceOf.call(BUYER_ADDRESS);
     totalWei = await instance.totalWei.call();
     balance = await web3.eth.getBalance(instance.address);
     totalRefunds_ = await instance.totalRefunds_.call();
@@ -335,13 +334,13 @@ it("revert: should refund ETH and return allocated token to pool", async () => {
 
 
     // revert
-    let revert = await instance.revertPurchase(accounts[1], {from: accounts[0], value: value, gas: 4712388, gasPrice: 100000000000}); //execute revert
+    let revert = await instance.revertPurchase(BUYER_ADDRESS, {from: CONTRACT_CREATOR_ADDRESS, value: value, gas: 4712388, gasPrice: 100000000000}); //execute revert
     console.log('revertPurchase (gasUsed): ', revert.receipt.gasUsed);
     assert.isTrue(findEvent(revert,"Transfer"));
 
     totalSupply = await instance.totalSupply.call();
     totalSale = await instance.totalSale.call();
-    balanceOf = await instance.balanceOf.call(accounts[1]);
+    balanceOf = await instance.balanceOf.call(BUYER_ADDRESS);
     totalWei = await instance.totalWei.call();
     balance = await web3.eth.getBalance(instance.address);
     totalRefunds_ = await instance.totalRefunds_.call();
@@ -350,6 +349,81 @@ it("revert: should refund ETH and return allocated token to pool", async () => {
     
     assert.isTrue(balanceOf.eq(0));
 
+});
+
+it("withdraw: should take everything out after Purchase put X ETH in contract", async () => {
+    // 0. Create contract, set to Sale, must be whitelisted
+    let instance = await TESTToken.new(NEUREAL_ETH_WALLET_ADDRESS, WHITELIST_PROVIDER_ADDRESS, {from: CONTRACT_CREATOR_ADDRESS, gas: deployGas, gasPrice: deployGasPrice});
+    await instance.transition({from: CONTRACT_CREATOR_ADDRESS});
+    await instance.whitelist(BUYER_ADDRESS, {from: WHITELIST_PROVIDER_ADDRESS});
+    let value = web3.toWei(0.01, "ether");
+    // 1. Purchase tokens on 0.01 ETH
+    await instance.sendTransaction({from: BUYER_ADDRESS, value: value});
+    // 2. Withdraw all contract balance ETH, except MAX_WEI_WITHDRAWAL value
+    let contractBalance = web3.eth.getBalance(instance.address);
+    await instance.withdraw({from: CONTRACT_CREATOR_ADDRESS});
+    // 3. Set Finalized phase for withdraw everything:
+    await instance.transition({from: CONTRACT_CREATOR_ADDRESS});
+    // 4. Withdraw all ETH
+    await instance.withdraw({from: CONTRACT_CREATOR_ADDRESS});
+    contractBalance = web3.eth.getBalance(instance.address);
+    // All eth was withdrawerd from contract balance:
+    assert.equal(contractBalance, 0)
+});
+
+it("withdraw: it should take only amount in contract, except X from purchase which is locked in revert pool", async () => {
+    // 0. Create contract, set to Sale, must be whitelisted
+    let instance = await TESTToken.new(NEUREAL_ETH_WALLET_ADDRESS, WHITELIST_PROVIDER_ADDRESS, {from: CONTRACT_CREATOR_ADDRESS, gas: deployGas, gasPrice: deployGasPrice});
+    await instance.transition({from: CONTRACT_CREATOR_ADDRESS});
+    await instance.whitelist(BUYER_ADDRESS, {from: WHITELIST_PROVIDER_ADDRESS});
+    let value = web3.toWei(0.01, "ether");
+    // 1. Purchase tokens on 0.01 ETH
+    await instance.sendTransaction({from: BUYER_ADDRESS, value: value});
+    // 2. Refund: Lock ETH to pendingRefund pool
+    await instance.revertPurchase(BUYER_ADDRESS, {from: CONTRACT_CREATOR_ADDRESS, value: value});
+    // 3. Withdraw all contract balance ETH, except pendingRefund value
+    await instance.withdraw({from: CONTRACT_CREATOR_ADDRESS});
+    // 4. Set Finalized phase for withdraw everything:
+    await instance.transition({from: CONTRACT_CREATOR_ADDRESS});
+    // 5. Withdraw all ETH
+    await instance.withdraw({from: CONTRACT_CREATOR_ADDRESS});
+    let contractBalance = web3.eth.getBalance(instance.address);
+    const bigValue = web3.toBigNumber(value)
+    // Withdraw everything except
+    assert.isTrue(contractBalance.eq(bigValue))
+    // 6. Send refund after
+    await instance.sendRefund(BUYER_ADDRESS);
+    contractBalance = web3.eth.getBalance(instance.address);
+    assert.equal(contractBalance, 0)
+});
+
+it("withdraw: It should take everything out, but the X from purchase should already be gone (SendRefund sends X ETH back to purchaser)", async () => {
+    // 0. Create contract, set to Sale, must be whitelisted
+    let instance = await TESTToken.new(NEUREAL_ETH_WALLET_ADDRESS, WHITELIST_PROVIDER_ADDRESS, {from: CONTRACT_CREATOR_ADDRESS, gas: deployGas, gasPrice: deployGasPrice});
+    await instance.transition({from: CONTRACT_CREATOR_ADDRESS});
+    await instance.whitelist(BUYER_ADDRESS, {from: WHITELIST_PROVIDER_ADDRESS});
+
+    let value = web3.toWei(0.01, "ether");
+    const bigValue = web3.toBigNumber(value)
+    // 1. Purchase tokens on 0.01 ETH
+    await instance.sendTransaction({from: BUYER_ADDRESS, value: value});
+    // 2. Refund: Lock ETH to pendingRefund pool
+    await instance.revertPurchase(BUYER_ADDRESS, {from: CONTRACT_CREATOR_ADDRESS, value: value});
+    let totalRefunds_ = await instance.totalRefunds_.call();
+    assert.isTrue(totalRefunds_.eq(bigValue), 'Check refund pool')
+    // 3. Send refund to Buyer
+    const balanceBefore = web3.eth.getBalance(instance.address);
+    await instance.sendRefund(BUYER_ADDRESS);
+    const balanceAfter = web3.eth.getBalance(instance.address);
+    assert.isTrue(balanceAfter.eq(balanceBefore.sub(bigValue)), 'Refund money should already be gone')
+    // 4. Withdraw all contract balance ETH, except MAX_WEI_WITHDRAWAL value
+    await instance.withdraw({from: CONTRACT_CREATOR_ADDRESS});
+    // 5. Set Finalized phase for withdraw everything:
+    await instance.transition({from: CONTRACT_CREATOR_ADDRESS});
+    // 6. Withdraw all ETH
+    await instance.withdraw({from: CONTRACT_CREATOR_ADDRESS});
+    let contractBalance = web3.eth.getBalance(instance.address);
+    assert.equal(contractBalance, 0)
 });
 
 });


### PR DESCRIPTION
- Should take everything out after Purchase put X ETH in contract
- It should take only amount in contract, except X from purchase which is locked in revert pool
- It should take everything out, but the X from purchase should already be gone (SendRefund sends X ETH back to purchaser